### PR TITLE
XML: Custom infix operators + Peephole optimizer (by Michael Gavrilenko, Danila Rudnev-Stepanyan and Daniel Vlasenko)

### DIFF
--- a/XML/bin/XML.ml
+++ b/XML/bin/XML.ml
@@ -20,19 +20,20 @@ type options =
   ; mutable gc_stats : bool
   ; mutable check_types : bool
   ; mutable show_types : bool
+  ; mutable optimize_peephole : bool
   }
 
 (* ------------------------------- *)
 (*     Compiler Entry Points       *)
 (* ------------------------------- *)
 
-let to_asm ~gc_stats ast : string =
+let to_asm ~opt_peephole ~gc_stats ast : string =
   let cc_program = Middleend.Cc.cc_program ast in
   let anf_ast = Middleend.Anf.anf_program cc_program in
   let ll_anf = Middleend.Ll.lambda_lift_program anf_ast in
   let buf = Buffer.create 1024 in
   let ppf = formatter_of_buffer buf in
-  Backend.Codegen.gen_program_with_gc_stats ~gc_stats ppf ll_anf;
+  Backend.Codegen.gen_program_with_gc_stats ~opt_peephole ~gc_stats ppf ll_anf;
   pp_print_flush ppf ();
   Buffer.contents buf
 ;;
@@ -69,7 +70,9 @@ let compile_and_write options source_code =
   then (
     Middleend.Pprinter.print_anf_program std_formatter anf_after_ll;
     exit 0);
-  let asm_code = to_asm ~gc_stats:options.gc_stats ast in
+  let asm_code =
+    to_asm ~opt_peephole:options.optimize_peephole ~gc_stats:options.gc_stats ast
+  in
   match options.output_file_name with
   | Some out_file ->
     (try
@@ -122,6 +125,7 @@ let () =
     ; gc_stats = false
     ; check_types = true
     ; show_types = false
+    ; optimize_peephole = true
     }
   in
   let usage_msg =
@@ -158,6 +162,9 @@ let () =
     ; ( "-typedtree"
       , Arg.Unit (fun () -> options.show_types <- true)
       , "         Show all names with their types and exit" )
+    ; ( "-no-opt-peep"
+      , Arg.Unit (fun () -> options.optimize_peephole <- false)
+      , "         Do not run peephole optimizer before code emission" )
     ]
   in
   let handle_anon_arg filename =

--- a/XML/lib/backend/codegen.ml
+++ b/XML/lib/backend/codegen.ml
@@ -3,6 +3,7 @@
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open Common.Ast
+open Common.Parser
 open Middleend.Anf
 open Format
 open Target
@@ -162,6 +163,11 @@ and gen_comp_expr (state : cg_state) (dst : reg) (cexpr : comp_expr) : cg_state 
     let* () = gen_im_expr state dst imm in
     ok state
   | Comp_binop (op, v1, v2) ->
+    let* () = gen_im_expr state (T 0) v1 in
+    let* () = gen_im_expr state (T 1) v2 in
+    emit_tagged_binop op dst (T 0) (T 1);
+    ok state
+  | Comp_app (Imm_ident op, [ v1; v2 ]) when is_operator_char op.[0] ->
     let* () = gen_im_expr state (T 0) v1 in
     let* () = gen_im_expr state (T 1) v2 in
     emit_tagged_binop op dst (T 0) (T 1);

--- a/XML/lib/backend/codegen.ml
+++ b/XML/lib/backend/codegen.ml
@@ -430,7 +430,7 @@ let prefill_arities (arity_map0 : ArityMap.t) (program : aprogram) : ArityMap.t 
     program
 ;;
 
-let gen_program_res_with_gc ~gc_stats ppf (program : aprogram) : unit r =
+let gen_program_res_with_gc ~opt_peephole ~gc_stats ppf (program : aprogram) : unit r =
   let has_main =
     List.exists
       (function
@@ -482,12 +482,12 @@ let gen_program_res_with_gc ~gc_stats ppf (program : aprogram) : unit r =
       drain st''
   in
   let* _st_final = drain st1 in
-  flush_queue ppf;
+  flush_queue ~opt_peephole ppf;
   ok ()
 ;;
 
-let gen_program_with_gc_stats ~gc_stats ppf (program : aprogram) =
-  match gen_program_res_with_gc ~gc_stats ppf program with
+let gen_program_with_gc_stats ~opt_peephole ~gc_stats ppf (program : aprogram) =
+  match gen_program_res_with_gc ~opt_peephole ~gc_stats ppf program with
   | Ok () -> ()
   | Error (`Unbound_identifier x) ->
     invalid_arg ("Unbound identifier during codegen: " ^ x)
@@ -506,6 +506,6 @@ let gen_program_with_gc_stats ~gc_stats ppf (program : aprogram) =
   | Error `Tuple_not_impl -> invalid_arg "Tuple values are not yet implemented"
 ;;
 
-let gen_program ppf (program : aprogram) =
-  gen_program_with_gc_stats ~gc_stats:false ppf program
+let gen_program ppf (program : aprogram) ~opt_peephole =
+  gen_program_with_gc_stats ~opt_peephole ~gc_stats:false ppf program
 ;;

--- a/XML/lib/backend/codegen.ml
+++ b/XML/lib/backend/codegen.ml
@@ -374,7 +374,6 @@ let gen_func
       (func_name : string)
       (params : ident list)
       (body_anf : anf_expr)
-      ppf
       (st : cg_state)
   : cg_state r
   =
@@ -408,7 +407,6 @@ let gen_func
   in
   let* state_after = gen_anf_expr initial_state_for_body (A 0) body_anf in
   if func_name = "main" && st.gc_stats then emit call "print_gc_status";
-  flush_queue ppf;
   emit_epilogue initial_frame_size;
   ok { st with next_label = state_after.next_label; deferred = state_after.deferred }
 ;;
@@ -456,7 +454,7 @@ let gen_program_res_with_gc ~gc_stats ppf (program : aprogram) : unit r =
       (fun acc_res item ->
          let* st = acc_res in
          match item with
-         | Anf_str_eval anf_expr -> gen_func ~arity_map "main" [] anf_expr ppf st
+         | Anf_str_eval anf_expr -> gen_func ~arity_map "main" [] anf_expr st
          | Anf_str_value (_rec_flag, name, anf_expr) ->
            let params, body =
              match anf_expr with
@@ -464,7 +462,7 @@ let gen_program_res_with_gc ~gc_stats ppf (program : aprogram) : unit r =
              | Anf_comp_expr (Comp_func (ps, b)) -> ps, b
              | _ -> [], anf_expr
            in
-           gen_func ~arity_map name params body ppf st)
+           gen_func ~arity_map name params body st)
       (ok st0)
       program
   in
@@ -477,7 +475,7 @@ let gen_program_res_with_gc ~gc_stats ppf (program : aprogram) : unit r =
         List.fold_left
           (fun acc_res (name, ps, body) ->
              let* st_acc = acc_res in
-             gen_func ~arity_map name ps body ppf st_acc)
+             gen_func ~arity_map name ps body st_acc)
           (ok st')
           (List.rev defs)
       in

--- a/XML/lib/backend/codegen.mli
+++ b/XML/lib/backend/codegen.mli
@@ -5,10 +5,11 @@
 open Format
 
 (* gens program on riscv asm from the ast *)
-val gen_program : formatter -> Middleend.Anf.aprogram -> unit
+val gen_program : formatter -> Middleend.Anf.aprogram -> opt_peephole:bool -> unit
 
 val gen_program_with_gc_stats
-  :  gc_stats:bool
+  :  opt_peephole:bool
+  -> gc_stats:bool
   -> formatter
   -> Middleend.Anf.aprogram
   -> unit

--- a/XML/lib/backend/codegen_llvm.ml
+++ b/XML/lib/backend/codegen_llvm.ml
@@ -5,6 +5,7 @@
 open Middleend.Anf
 open Common.Ast
 open Target
+open Common.Parser
 
 let context = Llvm.global_context ()
 let i64_type = Llvm.i64_type context
@@ -209,6 +210,8 @@ let build_apply_part fmap fclos args =
 let rec gen_comp_expr_ir fmap env = function
   | Comp_imm imm -> gen_im_expr_ir fmap env imm
   | Comp_binop (op, lhs, rhs) -> gen_tagged_binop fmap env op lhs rhs
+  | Comp_app (Imm_ident op, [ arg1; arg2 ]) when is_operator_char op.[0] ->
+    gen_tagged_binop fmap env op arg1 arg2
   | Comp_app (Imm_ident f, args) ->
     let f_map = if f = "main" then subst_main else f in
     (match FuncMap.find fmap f_map with
@@ -341,10 +344,12 @@ let gen_function fmap the_mod name params body =
 
 let gen_astructure_item fmap the_mod main_fn env = function
   | Anf_str_eval expr ->
+    Llvm.position_at_end (Llvm.entry_block main_fn) builder;
     let _, new_env = gen_anf_expr fmap env expr in
     new_env
   | Anf_str_value (_, name, Anf_comp_expr (Comp_func (params, body))) ->
     let _ = gen_function fmap the_mod name params body in
+    Llvm.position_at_end (Llvm.entry_block main_fn) builder;
     env
   | Anf_str_value (_, name, expr) ->
     Llvm.position_at_end (Llvm.entry_block main_fn) builder;

--- a/XML/lib/backend/dune
+++ b/XML/lib/backend/dune
@@ -1,7 +1,7 @@
 (library
  (name backend)
  (public_name XML.Backend)
- (modules codegen codegen_llvm emission machine target)
+ (modules codegen codegen_llvm emission machine target optimize)
  (libraries
   angstrom
   base

--- a/XML/lib/backend/emission.ml
+++ b/XML/lib/backend/emission.ml
@@ -6,14 +6,16 @@ open Format
 open Base
 open Machine
 open Target
+open Optimize
 
 module Emission = struct
   let code : (instr * string) Queue.t = Queue.create ()
   let emit ?(comm = "") push_instr = push_instr (fun i -> Queue.enqueue code (i, comm))
 
   let flush_queue ppf =
-    while not (Queue.is_empty code) do
-      let i, comm = Queue.dequeue_exn code in
+    let optimized = optimize code in
+    while not (Queue.is_empty optimized) do
+      let i, comm = Queue.dequeue_exn optimized in
       (match i with
        | Label _ -> fprintf ppf "%a" pp_instr i
        | _ -> fprintf ppf "  %a" pp_instr i);

--- a/XML/lib/backend/emission.ml
+++ b/XML/lib/backend/emission.ml
@@ -12,8 +12,8 @@ module Emission = struct
   let code : (instr * string) Queue.t = Queue.create ()
   let emit ?(comm = "") push_instr = push_instr (fun i -> Queue.enqueue code (i, comm))
 
-  let flush_queue ppf =
-    let optimized = optimize code in
+  let flush_queue ~opt_peephole ppf =
+    let optimized = if opt_peephole then optimize code else code in
     while not (Queue.is_empty optimized) do
       let i, comm = Queue.dequeue_exn optimized in
       (match i with

--- a/XML/lib/backend/emission.mli
+++ b/XML/lib/backend/emission.mli
@@ -5,7 +5,7 @@
 module Emission : sig
   val code : (Machine.instr * string) Base.Queue.t
   val emit : ?comm:string -> ((Machine.instr -> unit) -> 'a) -> 'a
-  val flush_queue : Format.formatter -> unit
+  val flush_queue : opt_peephole:bool -> Format.formatter -> unit
   val emit_tagged_binop : string -> Machine.reg -> Machine.reg -> Machine.reg -> unit
   val emit_prologue : string -> int -> unit
   val emit_epilogue : int -> unit

--- a/XML/lib/backend/machine.ml
+++ b/XML/lib/backend/machine.ml
@@ -56,6 +56,7 @@ type instr =
   | Xor of reg * reg * reg (* XOR *)
   | Xori of reg * reg * (int[@gen QCheck.Gen.nat_small]) (* XOR immediate *)
   | Beq of reg * reg * (string[@gen gen_label]) (* BEQ: branch if equal *)
+  | Bne of reg * reg * (string[@gen gen_label]) (* BNE: branch if not equal *)
   | Blt of reg * reg * (string[@gen gen_label]) (* BLT: branch if less than *)
   | Ble of reg * reg * (string[@gen gen_label]) (* BLE: branch if less or equal *)
   | Lla of reg * (string[@gen gen_label]) (* LLA: load address *)

--- a/XML/lib/backend/machine.ml
+++ b/XML/lib/backend/machine.ml
@@ -187,6 +187,7 @@ let pp_instr ppf =
   | Snez (rd, r1) -> fprintf ppf "snez %a, %a" pp_reg rd pp_reg r1
   | Mv (r1, r2) -> fprintf ppf "mv %a, %a" pp_reg r1 pp_reg r2
   | Beq (r1, r2, s) -> fprintf ppf "beq %a, %a, %s" pp_reg r1 pp_reg r2 s
+  | Bne (r1, r2, s) -> fprintf ppf "bne %a, %a, %s" pp_reg r1 pp_reg r2 s
   | Blt (r1, r2, s) -> fprintf ppf "blt %a, %a, %s" pp_reg r1 pp_reg r2 s
   | Ble (r1, r2, s) -> fprintf ppf "ble %a, %a, %s" pp_reg r1 pp_reg r2 s
   | La (r, label) -> fprintf ppf "la %a, %s" pp_reg r label

--- a/XML/lib/backend/machine.mli
+++ b/XML/lib/backend/machine.mli
@@ -30,6 +30,7 @@ type instr =
   | Xor of reg * reg * reg (* XOR *)
   | Xori of reg * reg * int (* XOR immediate *)
   | Beq of reg * reg * string (* BEQ: branch if equal *)
+  | Bne of reg * reg * string (* BNE: branch if not equal *)
   | Blt of reg * reg * string (* BLT: branch if less than *)
   | Ble of reg * reg * string (* BLE: branch if less or equal *)
   | Lla of reg * string (* LLA: load address *)

--- a/XML/lib/backend/machine.mli
+++ b/XML/lib/backend/machine.mli
@@ -49,6 +49,7 @@ type instr =
   | Srai of reg * reg * int (* >> imm (arith) *)
 
 val gen_instr : instr QCheck.Gen.t
+val equal_instr : instr -> instr -> bool
 val pp_instr : Format.formatter -> instr -> unit
 val addi : (instr -> 'a) -> reg -> reg -> int -> 'a
 val add : (instr -> 'a) -> reg -> reg -> reg -> 'a

--- a/XML/lib/backend/machine.mli
+++ b/XML/lib/backend/machine.mli
@@ -17,6 +17,7 @@ val pp_reg : Format.formatter -> reg -> unit
 type offset = reg * int
 
 val gen_offset : offset QCheck.Gen.t
+val equal_offset : offset -> offset -> bool
 
 type instr =
   | Addi of reg * reg * int (* ADD immediate *)

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -1,0 +1,26 @@
+(** Copyright 2026,  Mikhail Gavrilenko, Danila Rudnev-Stepanyan, Daniel Vlasenko*)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Base
+open Format
+open Machine
+open Target
+
+let rec elim_sd_ld = function
+  | (Sd (r1, o1), _) :: (Ld (r2, o2), _) :: rest
+    when equal_reg r1 r2 && equal_offset o1 o2 -> elim_sd_ld rest
+  | x :: rest -> x :: elim_sd_ld rest
+  | [] -> []
+;;
+
+let peephole code : (instr * string) Queue.t =
+  let code = Queue.to_list code in
+  let optimized = elim_sd_ld code in
+  Queue.of_list optimized
+;;
+
+let optimize code : (instr * string) Queue.t =
+  let code = peephole code in
+  code
+;;

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -3,9 +3,7 @@
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open Base
-open Format
 open Machine
-open Target
 
 let rec elim_sd_ld_same_reg = function
   | (Sd (r1, o1), _) :: (Ld (r2, o2), _) :: rest
@@ -31,6 +29,18 @@ let rec elim_addi_sd_mv_addi = function
     :: rest
     when aimm1 == -aimm2 && equal_reg sr mr2 -> elim_addi_sd_mv_addi (mv_i :: rest)
   | x :: rest -> x :: elim_addi_sd_mv_addi rest
+  | [] -> []
+;;
+
+let rec fold_constants = function
+  | (Li (lid, lii), _) :: (Sub (srd, sr1, sr2), _) :: rest when equal_reg lid sr2 ->
+    let addi = Addi (srd, sr1, -lii), "" in
+    fold_constants (addi :: rest)
+  | (Addi (aid1, ai1, aii1), _) :: (Addi (aid2, ai2, aii2), _) :: rest
+    when equal_reg aid1 ai1 && equal_reg aid1 ai2 ->
+    let addi = Addi (aid2, ai1, aii1 + aii2), "" in
+    fold_constants (addi :: rest)
+  | x :: rest -> x :: fold_constants rest
   | [] -> []
 ;;
 
@@ -76,11 +86,82 @@ let rec fold_branch = function
   | [] -> []
 ;;
 
+let is_arg_reg r =
+  equal_reg r (A 0)
+  || equal_reg r (A 1)
+  || equal_reg r (A 2)
+  || equal_reg r (A 3)
+  || equal_reg r (A 4)
+  || equal_reg r (A 5)
+  || equal_reg r (A 6)
+  || equal_reg r (A 7)
+;;
+
+let reg_used_in_instr reg instr =
+  match instr with
+  | Add (_, r1, r2)
+  | Sub (_, r1, r2)
+  | Mul (_, r1, r2)
+  | Slt (_, r1, r2)
+  | Xor (_, r1, r2)
+    when equal_reg reg r1 || equal_reg reg r2 -> true
+  | Seqz (_, r1)
+  | Snez (_, r1)
+  | Beq (_, r1, _)
+  | Addi (_, r1, _)
+  | Xori (_, r1, _)
+  | Sd (r1, _)
+  | Mv (_, r1)
+  | Slli (_, r1, _)
+  | Srai (_, r1, _)
+    when equal_reg reg r1 -> true
+  | Call _ when is_arg_reg reg -> true
+  | _ -> false
+;;
+
+let reg_modified_in_instr reg instr =
+  match instr with
+  | Add (r1, _, _)
+  | Sub (r1, _, _)
+  | Mul (r1, _, _)
+  | Slt (r1, _, _)
+  | Xor (r1, _, _)
+  | Seqz (r1, _)
+  | Snez (r1, _)
+  | Addi (r1, _, _)
+  | Xori (r1, _, _)
+  | Mv (r1, _)
+  | Slli (r1, _, _)
+  | Srai (r1, _, _)
+  | Lla (r1, _)
+  | Li (r1, _)
+  | Ld (r1, _)
+  | La (r1, _)
+    when equal_reg reg r1 -> true
+  | Call _ when is_arg_reg reg -> true
+  | _ -> false
+;;
+
+let rec elim_inverse_mv = function
+  | (Mv (md1, mv1), _) :: (Mv (md2, mv2), _) :: rest
+    when equal_reg md1 mv2 && equal_reg mv1 md2 -> elim_inverse_mv rest
+  | (Mv (md1, mv1), _) :: ((i2, _) as i2c) :: (Mv (md2, mv2), _) :: rest
+    when equal_reg md1 mv2 && equal_reg mv1 md2 && not (reg_used_in_instr md1 i2) ->
+    elim_inverse_mv (i2c :: rest) (* can eliminate both *)
+  | ((Mv (md1, mv1), _) as i1) :: ((i2, _) as i2c) :: (Mv (md2, mv2), _) :: rest
+    when equal_reg md1 mv2 && equal_reg mv1 md2 && not (reg_modified_in_instr md1 i2) ->
+    elim_inverse_mv (i1 :: i2c :: rest) (* can eliminate the second one *)
+  | x :: rest -> x :: elim_inverse_mv rest
+  | [] -> []
+;;
+
 let peephole code : (instr * string) Queue.t =
   let code = Queue.to_list code in
   let optimized = elim_sd_ld_same_reg code in
   let optimized = elim_sd_ld_same_offset optimized in
   let optimized = elim_addi_sd_mv_addi optimized in
+  let optimized = fold_constants optimized in
+  let optimized = elim_inverse_mv optimized in
   let optimized = fold_branch optimized in
   Queue.of_list optimized
 ;;

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -104,13 +104,14 @@ let reg_used_in_instr reg instr =
   | Mul (_, r1, r2)
   | Slt (_, r1, r2)
   | Xor (_, r1, r2)
+  | Sd (r1, (r2, _))
+  | Ld (r1, (r2, _))
     when equal_reg reg r1 || equal_reg reg r2 -> true
   | Seqz (_, r1)
   | Snez (_, r1)
   | Beq (_, r1, _)
   | Addi (_, r1, _)
   | Xori (_, r1, _)
-  | Sd (r1, _)
   | Mv (_, r1)
   | Slli (_, r1, _)
   | Srai (_, r1, _)
@@ -155,12 +156,57 @@ let rec elim_inverse_mv = function
   | [] -> []
 ;;
 
-let rec elim_li_mv_before_call = function
+let rec elim_load_mv_before_call = function
   | (Li (ld, lii), _) :: (Mv (md, m1), _) :: ((Call _, _) as ci) :: rest
     when equal_reg ld m1 ->
     let li = Li (md, lii), "" in
-    elim_li_mv_before_call (li :: ci :: rest)
-  | x :: rest -> x :: elim_li_mv_before_call rest
+    elim_load_mv_before_call (li :: ci :: rest)
+  | (Ld (ld, off), _) :: (Mv (md, m1), _) :: ((Call _, _) as ci) :: rest
+    when equal_reg ld m1 ->
+    let li = Ld (md, off), "" in
+    elim_load_mv_before_call (li :: ci :: rest)
+  | x :: rest -> x :: elim_load_mv_before_call rest
+  | [] -> []
+;;
+
+let rec fold_mv_smth = function
+  | (Mv (md, mv1), _) :: (Sd (sd, off), _) :: rest when equal_reg md sd ->
+    let i = Sd (mv1, off), "" in
+    fold_mv_smth (i :: rest)
+  | (Mv (md, mv1), _) :: (Addi (ad, a1, aimm), _) :: rest when equal_reg md a1 ->
+    let i = Addi (ad, mv1, aimm), "" in
+    fold_mv_smth (i :: rest)
+  | x :: rest -> x :: fold_mv_smth rest
+  | [] -> []
+;;
+
+let rec fold_addi_sp = function
+  (* todo: long addi sd chains *)
+  | (Addi (SP, SP, aimm1), _)
+    :: (Sd (sd1, (SP, _)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: ((Sd (_, (SP, si2)), _) as sdi2)
+    :: rest ->
+    let addi = Addi (SP, SP, aimm1 + aimm2), "" in
+    let sdi1 = Sd (sd1, (SP, si2 - aimm2)), "" in
+    fold_addi_sp (addi :: sdi1 :: sdi2 :: rest)
+  | (Addi (SP, SP, aimm1), _)
+    :: (Ld (ld, (SP, limm)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: rest ->
+    let li = Ld (ld, (SP, aimm1 - limm)), "" in
+    let addi = Addi (SP, SP, aimm1 + aimm2), "" in
+    fold_addi_sp (li :: addi :: rest)
+  | ((Ld (_, (SP, _)), _) as ldi1)
+    :: (Addi (SP, SP, aimm1), _)
+    :: (Ld (ld2, (SP, li2)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: rest ->
+    let ldi2 = Ld (ld2, (SP, aimm1 - li2)), "" in
+    let addi = Addi (SP, SP, aimm1 + aimm2), "" in
+    fold_addi_sp (ldi1 :: ldi2 :: addi :: rest)
+  (* | Sd :: Addi :: Sd :: rest ->  *)
+  | x :: rest -> x :: fold_addi_sp rest
   | [] -> []
 ;;
 
@@ -172,7 +218,9 @@ let peephole code : (instr * string) Queue.t =
   let optimized = fold_constants optimized in
   let optimized = elim_inverse_mv optimized in
   let optimized = fold_branch optimized in
-  let optimized = elim_li_mv_before_call optimized in
+  let optimized = elim_load_mv_before_call optimized in
+  let optimized = fold_mv_smth optimized in
+  let optimized = fold_addi_sp optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -156,16 +156,20 @@ let rec elim_inverse_mv = function
   | [] -> []
 ;;
 
-let rec elim_load_mv_before_call = function
+let rec elim_mv_before_call = function
   | (Li (ld, lii), _) :: (Mv (md, m1), _) :: ((Call _, _) as ci) :: rest
     when equal_reg ld m1 ->
     let li = Li (md, lii), "" in
-    elim_load_mv_before_call (li :: ci :: rest)
+    elim_mv_before_call (li :: ci :: rest)
   | (Ld (ld, off), _) :: (Mv (md, m1), _) :: ((Call _, _) as ci) :: rest
     when equal_reg ld m1 ->
     let li = Ld (md, off), "" in
-    elim_load_mv_before_call (li :: ci :: rest)
-  | x :: rest -> x :: elim_load_mv_before_call rest
+    elim_mv_before_call (li :: ci :: rest)
+  | (Mv (md1, mv1), _) :: (Mv (md2, mv2), _) :: ((Call _, _) as ci) :: rest
+    when equal_reg md1 mv2 ->
+    let mv = Mv (md2, mv1), "" in
+    elim_mv_before_call (mv :: ci :: rest)
+  | x :: rest -> x :: elim_mv_before_call rest
   | [] -> []
 ;;
 
@@ -176,12 +180,58 @@ let rec fold_mv_smth = function
   | (Mv (md, mv1), _) :: (Addi (ad, a1, aimm), _) :: rest when equal_reg md a1 ->
     let i = Addi (ad, mv1, aimm), "" in
     fold_mv_smth (i :: rest)
+  | (Mv (md, mv1), _) :: (Add (ad, a1, a2), _) :: rest
+    when equal_reg md a1 || equal_reg md a2 ->
+    let add = if equal_reg md a1 then Add (ad, mv1, a2), "" else Add (ad, a1, mv1), "" in
+    fold_mv_smth (add :: rest)
   | x :: rest -> x :: fold_mv_smth rest
   | [] -> []
 ;;
 
 let rec fold_addi_sp = function
-  (* todo: long addi sd chains *)
+  (* can't just do as is like with ld, but it happens on A registers, so i listed the cases *)
+  | (Addi (SP, SP, aimm1), _)
+    :: (Sd (r1, (SP, off1)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: (Sd (r2, (SP, off2)), _)
+    :: (Addi (SP, SP, aimm3), _)
+    :: (Sd (r3, (SP, off3)), _)
+    :: (Addi (SP, SP, aimm4), _)
+    :: (Sd (r4, (SP, off4)), _)
+    :: (Addi (SP, SP, aimm5), _)
+    :: ((Sd (_, (SP, _)), _) as sdi5)
+    :: rest ->
+    let addi = Addi (SP, SP, aimm1 + aimm2 + aimm3 + aimm4 + aimm5), "" in
+    let sdi1 = Sd (r1, (SP, off1 - aimm1 - aimm2 - aimm3 - aimm4)), "" in
+    let sdi2 = Sd (r2, (SP, off2 - aimm2 - aimm3 - aimm4)), "" in
+    let sdi3 = Sd (r3, (SP, off3 - aimm3 - aimm4)), "" in
+    let sdi4 = Sd (r4, (SP, off4 - aimm4)), "" in
+    fold_addi_sp (addi :: sdi1 :: sdi2 :: sdi3 :: sdi4 :: sdi5 :: rest)
+  | (Addi (SP, SP, aimm1), _)
+    :: (Sd (r1, (SP, off1)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: (Sd (r2, (SP, off2)), _)
+    :: (Addi (SP, SP, aimm3), _)
+    :: (Sd (r3, (SP, off3)), _)
+    :: (Addi (SP, SP, aimm4), _)
+    :: ((Sd (_, (SP, _)), _) as sdi4)
+    :: rest ->
+    let addi = Addi (SP, SP, aimm1 + aimm2 + aimm3 + aimm4), "" in
+    let sdi1 = Sd (r1, (SP, off1 - aimm1 - aimm2 - aimm3)), "" in
+    let sdi2 = Sd (r2, (SP, off2 - aimm2 - aimm3)), "" in
+    let sdi3 = Sd (r3, (SP, off3 - aimm3)), "" in
+    fold_addi_sp (addi :: sdi1 :: sdi2 :: sdi3 :: sdi4 :: rest)
+  | (Addi (SP, SP, aimm1), _)
+    :: (Sd (r1, (SP, off1)), _)
+    :: (Addi (SP, SP, aimm2), _)
+    :: (Sd (r2, (SP, off2)), _)
+    :: (Addi (SP, SP, aimm3), _)
+    :: ((Sd (_, (SP, _)), _) as sdi3)
+    :: rest ->
+    let addi = Addi (SP, SP, aimm1 + aimm2 + aimm3), "" in
+    let sdi1 = Sd (r1, (SP, off1 - aimm1 - aimm2)), "" in
+    let sdi2 = Sd (r2, (SP, off2 - aimm2)), "" in
+    fold_addi_sp (addi :: sdi1 :: sdi2 :: sdi3 :: rest)
   | (Addi (SP, SP, aimm1), _)
     :: (Sd (sd1, (SP, _)), _)
     :: (Addi (SP, SP, aimm2), _)
@@ -205,8 +255,43 @@ let rec fold_addi_sp = function
     let ldi2 = Ld (ld2, (SP, aimm1 - li2)), "" in
     let addi = Addi (SP, SP, aimm1 + aimm2), "" in
     fold_addi_sp (ldi1 :: ldi2 :: addi :: rest)
-  (* | Sd :: Addi :: Sd :: rest ->  *)
+  | (Addi (SP, SP, aimm1), _) :: ((i, _) as i2) :: (Addi (SP, SP, aimm2), _) :: rest
+    when aimm1 = -aimm2 && not (reg_used_in_instr SP i) -> fold_addi_sp (i2 :: rest)
   | x :: rest -> x :: fold_addi_sp rest
+  | [] -> []
+;;
+
+let rec elim_sd_before_ret = function
+  | (Sd (_, _), _) :: ((Ret, _) as ret) :: rest -> elim_sd_before_ret (ret :: rest)
+  | (Sd (_, _), _) :: addi_sp :: ld_ra :: ld_s0 :: ((Ret, _) as ret) :: rest ->
+    elim_sd_before_ret (addi_sp :: ld_ra :: ld_s0 :: ret :: rest)
+  | (Sd (_, (reg, _)), _)
+    :: ((i, _) as ic)
+    :: addi_sp
+    :: ld_ra
+    :: ld_s0
+    :: ((Ret, _) as ret)
+    :: rest
+    when not (reg_used_in_instr reg i) ->
+    elim_sd_before_ret (ic :: addi_sp :: ld_ra :: ld_s0 :: ret :: rest)
+  | x :: rest -> x :: elim_sd_before_ret rest
+  | [] -> []
+;;
+
+let rec elim_mv_before_branch = function
+  | (Mv (md, mv1), _) :: ((Li (ld, _), _) as li) :: (Bne (br1, br2, label), _) :: rest
+    when equal_reg md br1 && equal_reg ld br2 ->
+    let b = Bne (mv1, ld, label), "" in
+    fold_branch (li :: b :: rest)
+  | (Mv (md, mv1), _) :: ((Li (ld, _), _) as li) :: (Blt (br1, br2, label), _) :: rest
+    when equal_reg md br2 && equal_reg ld br1 ->
+    let b = Blt (ld, mv1, label), "" in
+    fold_branch (li :: b :: rest)
+  | (Mv (md, mv1), _) :: ((Li (ld, _), _) as li) :: (Ble (br1, br2, label), _) :: rest
+    when equal_reg md br2 && equal_reg ld br1 ->
+    let b = Ble (ld, mv1, label), "" in
+    fold_branch (li :: b :: rest)
+  | x :: rest -> x :: elim_mv_before_branch rest
   | [] -> []
 ;;
 
@@ -218,9 +303,11 @@ let peephole code : (instr * string) Queue.t =
   let optimized = fold_constants optimized in
   let optimized = elim_inverse_mv optimized in
   let optimized = fold_branch optimized in
-  let optimized = elim_load_mv_before_call optimized in
+  let optimized = elim_mv_before_call optimized in
   let optimized = fold_mv_smth optimized in
   let optimized = fold_addi_sp optimized in
+  let optimized = elim_sd_before_ret optimized in
+  let optimized = elim_mv_before_branch optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -23,10 +23,22 @@ let rec elim_sd_ld_same_offset = function
   | [] -> []
 ;;
 
+let rec elim_addi_sd_mv_addi = function
+  | (Addi (_, _, aimm1), _)
+    :: (Sd (sr, _), _)
+    :: ((Mv (_, mr2), _) as mv_i)
+    :: (Addi (_, _, aimm2), _)
+    :: rest
+    when aimm1 == -aimm2 && equal_reg sr mr2 -> elim_addi_sd_mv_addi (mv_i :: rest)
+  | x :: rest -> x :: elim_addi_sd_mv_addi rest
+  | [] -> []
+;;
+
 let peephole code : (instr * string) Queue.t =
   let code = Queue.to_list code in
   let optimized = elim_sd_ld_same_reg code in
   let optimized = elim_sd_ld_same_offset optimized in
+  let optimized = elim_addi_sd_mv_addi optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -155,6 +155,15 @@ let rec elim_inverse_mv = function
   | [] -> []
 ;;
 
+let rec elim_li_mv_before_call = function
+  | (Li (ld, lii), _) :: (Mv (md, m1), _) :: ((Call _, _) as ci) :: rest
+    when equal_reg ld m1 ->
+    let li = Li (md, lii), "" in
+    elim_li_mv_before_call (li :: ci :: rest)
+  | x :: rest -> x :: elim_li_mv_before_call rest
+  | [] -> []
+;;
+
 let peephole code : (instr * string) Queue.t =
   let code = Queue.to_list code in
   let optimized = elim_sd_ld_same_reg code in
@@ -163,6 +172,7 @@ let peephole code : (instr * string) Queue.t =
   let optimized = fold_constants optimized in
   let optimized = elim_inverse_mv optimized in
   let optimized = fold_branch optimized in
+  let optimized = elim_li_mv_before_call optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -97,8 +97,7 @@ let is_arg_reg r =
   || equal_reg r (A 7)
 ;;
 
-let reg_used_in_instr reg instr =
-  match instr with
+let reg_used_in_instr reg = function
   | Add (_, r1, r2)
   | Sub (_, r1, r2)
   | Mul (_, r1, r2)
@@ -120,8 +119,7 @@ let reg_used_in_instr reg instr =
   | _ -> false
 ;;
 
-let reg_modified_in_instr reg instr =
-  match instr with
+let reg_modified_in_instr reg = function
   | Add (r1, _, _)
   | Sub (r1, _, _)
   | Mul (r1, _, _)

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -27,7 +27,7 @@ let rec elim_addi_sd_mv_addi = function
     :: ((Mv (_, mr2), _) as mv_i)
     :: (Addi (_, _, aimm2), _)
     :: rest
-    when aimm1 == -aimm2 && equal_reg sr mr2 -> elim_addi_sd_mv_addi (mv_i :: rest)
+    when aimm1 = -aimm2 && equal_reg sr mr2 -> elim_addi_sd_mv_addi (mv_i :: rest)
   | x :: rest -> x :: elim_addi_sd_mv_addi rest
   | [] -> []
 ;;

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -7,16 +7,26 @@ open Format
 open Machine
 open Target
 
-let rec elim_sd_ld = function
+let rec elim_sd_ld_same_reg = function
   | (Sd (r1, o1), _) :: (Ld (r2, o2), _) :: rest
-    when equal_reg r1 r2 && equal_offset o1 o2 -> elim_sd_ld rest
-  | x :: rest -> x :: elim_sd_ld rest
+    when equal_reg r1 r2 && equal_offset o1 o2 -> elim_sd_ld_same_reg rest
+  | x :: rest -> x :: elim_sd_ld_same_reg rest
+  | [] -> []
+;;
+
+let rec elim_sd_ld_same_offset = function
+  | ((Sd (r1, o1), _) as i1) :: (Ld (r2, o2), _) :: rest
+    when (not (equal_reg r1 r2)) && equal_offset o1 o2 ->
+    let new_i = Mv (r2, r1), "" in
+    elim_sd_ld_same_offset (i1 :: new_i :: rest)
+  | x :: rest -> x :: elim_sd_ld_same_offset rest
   | [] -> []
 ;;
 
 let peephole code : (instr * string) Queue.t =
   let code = Queue.to_list code in
-  let optimized = elim_sd_ld code in
+  let optimized = elim_sd_ld_same_reg code in
+  let optimized = elim_sd_ld_same_offset optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -278,6 +278,20 @@ let rec elim_sd_before_ret = function
   | [] -> []
 ;;
 
+let rec elim_id_fun = function
+  | (Addi (SP, SP, _), _)
+    :: (Sd (RA, _), _)
+    :: (Sd (S 0, _), _)
+    :: (Addi (S 0, _, _), _)
+    :: (Addi (SP, _, _), _)
+    :: (Ld (RA, _), _)
+    :: (Ld (S 0, _), _)
+    :: ((Ret, _) as ret)
+    :: rest -> elim_id_fun (ret :: rest)
+  | x :: rest -> x :: elim_id_fun rest
+  | [] -> []
+;;
+
 let rec elim_mv_before_branch = function
   | (Mv (md, mv1), _) :: ((Li (ld, _), _) as li) :: (Bne (br1, br2, label), _) :: rest
     when equal_reg md br1 && equal_reg ld br2 ->
@@ -308,6 +322,7 @@ let peephole code : (instr * string) Queue.t =
   let optimized = fold_addi_sp optimized in
   let optimized = elim_sd_before_ret optimized in
   let optimized = elim_mv_before_branch optimized in
+  let optimized = elim_id_fun optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.ml
+++ b/XML/lib/backend/optimize.ml
@@ -34,11 +34,54 @@ let rec elim_addi_sd_mv_addi = function
   | [] -> []
 ;;
 
+let rec fold_branch = function
+  | (Slt (sld, sl1, sl2), _) :: (Beq (brc, Zero, label), _) :: rest when equal_reg sld brc
+    ->
+    let br = Ble (sl2, sl1, label), "" in
+    fold_branch (br :: rest)
+  | ((Li (lid, _), _) as li)
+    :: (Xor (xd, x1, x2), _)
+    :: (Seqz (sd, s1), _)
+    :: (Beq (br, Zero, label), _)
+    :: rest
+    when equal_reg lid x2 && equal_reg xd s1 && equal_reg sd br ->
+    let br = Bne (x1, x2, label), "" in
+    fold_branch (li :: br :: rest)
+  | ((Li (lid, _), _) as li)
+    :: (Slt (sld, sl1, sl2), _)
+    :: (Seqz (sd, s1), _)
+    :: (Beq (br, Zero, label), _)
+    :: rest
+    when equal_reg lid sl1 && equal_reg sld s1 && equal_reg sd br ->
+    let br = Blt (lid, sl2, label), "" in
+    fold_branch (li :: br :: rest)
+  | ((Li (lid, _), _) as li)
+    :: (Xor (xd, x1, x2), _)
+    :: (Snez (snd, sn1), _)
+    :: (Beq (br, Zero, label), _)
+    :: rest
+    when equal_reg lid x2 && equal_reg xd sn1 && equal_reg snd br ->
+    let br = Beq (x1, lid, label), "" in
+    fold_branch (li :: br :: rest)
+  | ((Mv (mvd, mv1), _) as li)
+    :: (Xor (xd, x1, x2), _)
+    :: (Snez (snd, sn1), _)
+    :: (Beq (br, Zero, label), _)
+    :: rest
+    when equal_reg mvd x2 && equal_reg xd sn1 && equal_reg snd br ->
+    let br = Beq (x1, mv1, label), "" in
+    fold_branch (li :: br :: rest)
+  (* | XOR :: SNEZ :: BEQ *)
+  | x :: rest -> x :: fold_branch rest
+  | [] -> []
+;;
+
 let peephole code : (instr * string) Queue.t =
   let code = Queue.to_list code in
   let optimized = elim_sd_ld_same_reg code in
   let optimized = elim_sd_ld_same_offset optimized in
   let optimized = elim_addi_sd_mv_addi optimized in
+  let optimized = fold_branch optimized in
   Queue.of_list optimized
 ;;
 

--- a/XML/lib/backend/optimize.mli
+++ b/XML/lib/backend/optimize.mli
@@ -1,0 +1,11 @@
+(** Copyright 2026,  Mikhail Gavrilenko, Danila Rudnev-Stepanyan, Daniel Vlasenko*)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Format
+open Base
+open Machine
+open Target
+
+(** [optimize instrs] performs optimizations on the code [instrs] *)
+val optimize : (instr * string) Queue.t -> (instr * string) Queue.t

--- a/XML/lib/backend/optimize.mli
+++ b/XML/lib/backend/optimize.mli
@@ -2,10 +2,8 @@
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
-open Format
 open Base
 open Machine
-open Target
 
 (** [optimize instrs] performs optimizations on the code [instrs] *)
 val optimize : (instr * string) Queue.t -> (instr * string) Queue.t

--- a/XML/lib/common/parser.ml
+++ b/XML/lib/common/parser.ml
@@ -501,7 +501,7 @@ let rec parseprefop pexpr pop =
 
 let parse_infix_startw starts =
   let* op = pass_ws *> pinfix_op ~starts () <* pass_ws in
-  return (fun e1 e2 -> Expression.Exp_apply (Exp_ident op, Exp_tuple (e1, e2, [])))
+  return (fun e1 e2 -> Expression.Exp_apply (Exp_apply (Exp_ident op, e1), e2))
 ;;
 
 let padd = parse_infix_startw "+"

--- a/XML/lib/common/parser.ml
+++ b/XML/lib/common/parser.ml
@@ -499,17 +499,26 @@ let rec parseprefop pexpr pop =
   <|> pexpr
 ;;
 
-let parsebinop starts =
+let parse_infix_startw starts =
   let* op = pass_ws *> pinfix_op ~starts () <* pass_ws in
   return (fun e1 e2 -> Expression.Exp_apply (Exp_ident op, Exp_tuple (e1, e2, [])))
 ;;
 
-let padd = parsebinop "+"
-let psub = parsebinop "-"
-let pdiv = parsebinop "/"
-let pmul = parsebinop "*"
-let pcompops = choice [ parsebinop "="; parsebinop "<"; parsebinop ">"; parsebinop "$" ]
-let plogops = choice [ parsebinop "&&"; parsebinop "||" ]
+let padd = parse_infix_startw "+"
+let psub = parse_infix_startw "-"
+let pdiv = parse_infix_startw "/"
+let pmul = parse_infix_startw "*"
+
+let pcompops =
+  choice
+    [ parse_infix_startw "="
+    ; parse_infix_startw "<"
+    ; parse_infix_startw ">"
+    ; parse_infix_startw "$"
+    ]
+;;
+
+let plogops = choice [ parse_infix_startw "&&"; parse_infix_startw "||" ]
 
 let pexprconstraint pexpr =
   let* expr = token "(" *> pexpr in
@@ -559,12 +568,14 @@ let pexpr =
          >>| fun id expr -> Expression.Exp_apply (Exp_ident id, expr))
       <|> papply
     in
-    let pinfix1 = lchain pprefix1 (pmul <|> pdiv) in
-    let pinfix2 = lchain pinfix1 (padd <|> psub) in
-    let pinfix3 = lchain pinfix2 pcompops in
-    let pinfix4 = pexpcons pinfix3 <|> pinfix3 in
-    let pinfix5 = rchain pinfix4 plogops in
-    let ptuple = ptupleexpr pinfix5 <|> pinfix5 in
+    let pinfix = lchain pprefix1 (parse_infix_startw "**") in
+    let pinfix = lchain pinfix (parse_infix_startw "*" <|> parse_infix_startw "/") in
+    let pinfix = lchain pinfix (parse_infix_startw "+" <|> parse_infix_startw "-") in
+    let pinfix = pexpcons pinfix <|> pinfix in
+    let pinfix = lchain pinfix (parse_infix_startw "@" <|> parse_infix_startw "^") in
+    let pinfix = lchain pinfix pcompops in
+    let pinfix = rchain pinfix plogops in
+    let ptuple = ptupleexpr pinfix <|> pinfix in
     choice
       [ pfunction pexpr; pfunexpr pexpr; pletexpr pexpr; pifexpr pexpr; pmatch pexpr ]
     <|> ptuple)

--- a/XML/lib/common/parser.ml
+++ b/XML/lib/common/parser.ml
@@ -48,6 +48,48 @@ let pident_cap =
   else fail "Found a keyword instead of an identifier"
 ;;
 
+(* https://ocaml.org/manual/5.4/lex.html#start-section *)
+let is_core_operator_char = function
+  | '$' | '&' | '*' | '+' | '-' | '/' | '=' | '>' | '@' | '^' -> true
+  | _ -> false
+;;
+
+let is_operator_char = function
+  | x when is_core_operator_char x -> true
+  | '~' | '!' | '?' | ':' | '.' | '<' | '%' -> true
+  | _ -> false
+;;
+
+let pinfix_symbol ?starts () =
+  let* p1 =
+    Option.value_map
+      starts
+      ~f:string
+      ~default:(char '%' <|> char '<' <|> satisfy is_core_operator_char >>| Char.to_string)
+  in
+  let* p2 = take_while is_operator_char in
+  return (p1 ^ p2)
+;;
+
+let pinfix_op ?starts () =
+  let pbin =
+    string "*"
+    <|> string "+"
+    <|> string "-"
+    <|> string "="
+    <|> string "!="
+    <|> string "<"
+    <|> string ">"
+    <|> string "||"
+    <|> string "|"
+    <|> string "&&"
+  in
+  Option.value_map
+    starts
+    ~f:(fun s -> pinfix_symbol ~starts:s ())
+    ~default:(pinfix_symbol () <|> pbin)
+;;
+
 let pident_lc =
   let first_char_str =
     satisfy (function
@@ -279,7 +321,7 @@ let ptuplepat ppattern =
 ;;
 
 let ppatvar =
-  let* id = pident_lc in
+  let* id = pident_lc <|> pparenth (pinfix_op ()) in
   match id with
   | "_" -> return Pattern.Pat_any
   | _ -> return (Pattern.Pat_var id)
@@ -521,19 +563,19 @@ let pexpr =
       return (Expression.Exp_apply (constr, arg))
     in
     let papply = lchain (pconstructor_apply <|> poprnd) papplyexpr in
-    let prefop =
+    let pprefix1 =
       parseprefop
         papply
         (choice [ token "+"; token "-" ]
          >>| fun id expr -> Expression.Exp_apply (Exp_ident id, expr))
       <|> papply
     in
-    let pmuldiv = lchain prefop (pmul <|> pdiv) in
-    let paddsub = lchain pmuldiv (padd <|> psub) in
-    let pcompare = lchain paddsub pcompops in
-    let pexpcons = pexpcons pcompare <|> pcompare in
-    let plogop = rchain pexpcons plogops in
-    let ptuple = ptupleexpr plogop <|> plogop in
+    let pinfix1 = lchain pprefix1 (pmul <|> pdiv) in
+    let pinfix2 = lchain pinfix1 (padd <|> psub) in
+    let pinfix3 = lchain pinfix2 pcompops in
+    let pinfix4 = pexpcons pinfix3 <|> pinfix3 in
+    let pinfix5 = rchain pinfix4 plogops in
+    let ptuple = ptupleexpr pinfix5 <|> pinfix5 in
     choice
       [ pfunction pexpr; pfunexpr pexpr; pletexpr pexpr; pifexpr pexpr; pmatch pexpr ]
     <|> ptuple)

--- a/XML/lib/common/parser.ml
+++ b/XML/lib/common/parser.ml
@@ -399,6 +399,7 @@ let pexprconst =
 
 let pidentexpr =
   pident_lc
+  <|> pparenth (pinfix_op ())
   >>= fun ident ->
   if is_not_keyword ident
   then return (Expression.Exp_ident ident)
@@ -498,28 +499,16 @@ let rec parseprefop pexpr pop =
   <|> pexpr
 ;;
 
-let parsebinop binoptoken =
-  token binoptoken
-  *> return (fun e1 e2 ->
-    Expression.Exp_apply (Exp_ident binoptoken, Exp_tuple (e1, e2, [])))
+let parsebinop starts =
+  let* op = pass_ws *> pinfix_op ~starts () <* pass_ws in
+  return (fun e1 e2 -> Expression.Exp_apply (Exp_ident op, Exp_tuple (e1, e2, [])))
 ;;
 
 let padd = parsebinop "+"
 let psub = parsebinop "-"
 let pdiv = parsebinop "/"
 let pmul = parsebinop "*"
-
-let pcompops =
-  choice
-    [ parsebinop ">="
-    ; parsebinop "<="
-    ; parsebinop "<>"
-    ; parsebinop "<"
-    ; parsebinop ">"
-    ; parsebinop "="
-    ]
-;;
-
+let pcompops = choice [ parsebinop "="; parsebinop "<"; parsebinop ">"; parsebinop "$" ]
 let plogops = choice [ parsebinop "&&"; parsebinop "||" ]
 
 let pexprconstraint pexpr =

--- a/XML/lib/common/parser.mli
+++ b/XML/lib/common/parser.mli
@@ -12,6 +12,8 @@ val pass_ws : unit Angstrom.t
 val pass_ws1 : unit Angstrom.t
 val token : string -> string Angstrom.t
 val pparenth : 'a Angstrom.t -> 'a Angstrom.t
+val is_operator_char : char -> bool
+val pinfix_op : ?starts:string -> unit -> string Angstrom.t
 val pident_cap : string Angstrom.t
 val pident_lc : string Angstrom.t
 val pconstint : Constant.t Angstrom.t

--- a/XML/lib/common/pprinter.ml
+++ b/XML/lib/common/pprinter.ml
@@ -247,48 +247,44 @@ let rec pprint_expression fmt n =
         exp
     in
     if n > 0 then fprintf fmt "(%s)" if_string else fprintf fmt "%s" if_string
-  | Exp_apply (ex1, ex2) ->
-    let op_pr = get_op_pr ex1 in
+  | Exp_apply (Exp_apply (id, first), second) ->
+    let op_pr = get_op_pr id in
     let format_apply =
-      match ex1, ex2 with
-      | _, Expression.Exp_tuple (first, second, _)
-        when List.mem [ 0; 1; 2; 3; 4; 5; 6 ] op_pr ~equal:Int.equal ->
+      match id, second with
+      | Exp_ident op, _ when is_operator_char op.[0] ->
+        (* Binary operator case *)
         let left_pr, right_pr =
           if List.mem [ 2; 3 ] op_pr ~equal:Int.equal
           then op_pr + 1, op_pr
           else op_pr, op_pr + 1
         in
         asprintf
-          "%a %a %a"
+          "%a %s %a"
           (fun fmt -> pprint_expression fmt left_pr)
           first
-          (fun fmt -> pprint_expression fmt op_pr)
-          ex1
+          op
           (fun fmt -> pprint_expression fmt right_pr)
           second
-      | Exp_ident id, _ ->
-        if is_operator_char id.[0]
-        then
-          asprintf
-            "(%a) %a"
-            (fun fmt -> pprint_expression fmt (op_pr + 1))
-            ex1
-            (fun fmt -> pprint_expression fmt (op_pr + 1))
-            ex2
-        else
-          asprintf
-            "%a %a"
-            (fun fmt -> pprint_expression fmt (op_pr + 1))
-            ex1
-            (fun fmt -> pprint_expression fmt (op_pr + 1))
-            ex2
       | _ ->
+        (* Not a binary operator - regular function application *)
         asprintf
           "%a %a"
           (fun fmt -> pprint_expression fmt (op_pr + 1))
-          ex1
+          (Exp_apply (id, first))
           (fun fmt -> pprint_expression fmt (op_pr + 1))
-          ex2
+          second
+    in
+    if n > op_pr then fprintf fmt "(%s)" format_apply else fprintf fmt "%s" format_apply
+  | Exp_apply (f, arg) ->
+    (* Handle other application cases *)
+    let op_pr = get_op_pr f in
+    let format_apply =
+      asprintf
+        "%a %a"
+        (fun fmt -> pprint_expression fmt (op_pr + 1))
+        f
+        (fun fmt -> pprint_expression fmt (op_pr + 1))
+        arg
     in
     if n > op_pr then fprintf fmt "(%s)" format_apply else fprintf fmt "%s" format_apply
   | Exp_match (ex, (cs, csl)) ->

--- a/XML/lib/common/pprinter.ml
+++ b/XML/lib/common/pprinter.ml
@@ -194,8 +194,8 @@ let rec pprint_pattern fmt =
   function
   | Pat_constraint (p, tye) -> fprintf fmt "(%a : %a)" pprint_pattern p pprint_type tye
   | Pat_any -> fprintf fmt "_"
-  | Pat_var id ->
-    if is_operator_char id.[0] then fprintf fmt "(%s)" id else fprintf fmt "%s" id
+  | Pat_var id when is_operator_char id.[0] -> fprintf fmt "(%s)" id
+  | Pat_var id -> fprintf fmt "%s" id
   | Pat_constant c -> pprint_constant fmt c
   | Pat_tuple (p1, p2, pl) ->
     fprintf

--- a/XML/lib/common/pprinter.ml
+++ b/XML/lib/common/pprinter.ml
@@ -21,12 +21,18 @@ let get_op_pr id =
   | Exp_ident "=" -> 4
   | Exp_ident "+" | Exp_ident "-" -> 5
   | Exp_ident "*" | Exp_ident "/" -> 6
+  | Exp_ident name ->
+    (match name.[0] with
+     | '*' | '/' | '%' -> 6
+     | '+' | '-' -> 5
+     | '=' | '<' | '>' | '|' | '&' | '$' -> 4
+     | _ -> 0)
   | Exp_if (_, _, _) -> 1
   | Exp_let (_, _, _)
   | Exp_match (_, _)
   | Exp_function _
   | Exp_fun (_, _)
-  | Exp_constant _ | Exp_ident _ -> 0
+  | Exp_constant _ -> 0
   | Exp_apply (_, _) | Exp_construct _ -> 7
   | _ -> 0
 ;;
@@ -244,9 +250,9 @@ let rec pprint_expression fmt n =
   | Exp_apply (ex1, ex2) ->
     let op_pr = get_op_pr ex1 in
     let format_apply =
-      match ex2 with
-      | Expression.Exp_tuple (first, second, _)
-        when List.mem [ 2; 3; 4; 5; 6 ] op_pr ~equal:Int.equal ->
+      match ex1, ex2 with
+      | _, Expression.Exp_tuple (first, second, _)
+        when List.mem [ 0; 1; 2; 3; 4; 5; 6 ] op_pr ~equal:Int.equal ->
         let left_pr, right_pr =
           if List.mem [ 2; 3 ] op_pr ~equal:Int.equal
           then op_pr + 1, op_pr
@@ -260,6 +266,22 @@ let rec pprint_expression fmt n =
           ex1
           (fun fmt -> pprint_expression fmt right_pr)
           second
+      | Exp_ident id, _ ->
+        if is_operator_char id.[0]
+        then
+          asprintf
+            "(%a) %a"
+            (fun fmt -> pprint_expression fmt (op_pr + 1))
+            ex1
+            (fun fmt -> pprint_expression fmt (op_pr + 1))
+            ex2
+        else
+          asprintf
+            "%a %a"
+            (fun fmt -> pprint_expression fmt (op_pr + 1))
+            ex1
+            (fun fmt -> pprint_expression fmt (op_pr + 1))
+            ex2
       | _ ->
         asprintf
           "%a %a"

--- a/XML/lib/common/pprinter.ml
+++ b/XML/lib/common/pprinter.ml
@@ -3,6 +3,7 @@
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open Base
+open Parser
 open Angstrom
 open Ast
 open Stdlib.Format
@@ -187,7 +188,8 @@ let rec pprint_pattern fmt =
   function
   | Pat_constraint (p, tye) -> fprintf fmt "(%a : %a)" pprint_pattern p pprint_type tye
   | Pat_any -> fprintf fmt "_"
-  | Pat_var id -> fprintf fmt "%s" id
+  | Pat_var id ->
+    if is_operator_char id.[0] then fprintf fmt "(%s)" id else fprintf fmt "%s" id
   | Pat_constant c -> pprint_constant fmt c
   | Pat_tuple (p1, p2, pl) ->
     fprintf

--- a/XML/lib/middleend/anf.ml
+++ b/XML/lib/middleend/anf.ml
@@ -158,16 +158,7 @@ let rec norm_comp expr (k : comp_expr -> nstate -> (anf_expr * nstate) r) (st : 
       (fun v1 ->
          norm_to_imm expr2 (fun v2 ->
            fun st ->
-           let ce =
-             match v1, v2 with
-             | Imm_num n1, Imm_num n2 ->
-               (match op with
-                | "+" -> Comp_imm (Imm_num (n1 + n2))
-                | "-" -> Comp_imm (Imm_num (n1 - n2))
-                | "*" -> Comp_imm (Imm_num (n1 * n2))
-                | _ -> Comp_binop (op, v1, v2))
-             | _ -> Comp_binop (op, v1, v2)
-           in
+           let ce = Comp_app (Imm_ident op, [ v1; v2 ]) in
            k ce st))
       st
   | Exp_apply (func_expr, arg_expr) ->

--- a/XML/lib/middleend/anf.ml
+++ b/XML/lib/middleend/anf.ml
@@ -6,6 +6,7 @@ open Common.Ast.Expression
 open Common.Ast.Constant
 open Common.Ast.Structure
 open Common.Ast
+open Common.Parser
 
 (* Immediate, atomic expressions that do not require the reduction *)
 type im_expr =
@@ -151,8 +152,7 @@ let rec norm_comp expr (k : comp_expr -> nstate -> (anf_expr * nstate) r) (st : 
   | Exp_tuple (expr1, expr2, rest_list) ->
     let all_exprs = expr1 :: expr2 :: rest_list in
     norm_list_to_imm all_exprs (fun imm_list st -> k (Comp_alloc imm_list) st) st
-  | Exp_apply (Exp_ident op, Exp_tuple (expr1, expr2, []))
-    when List.mem op [ "+"; "-"; "*"; "="; "<"; ">"; "<="; ">="; "<>" ] ->
+  | Exp_apply (Exp_apply (Exp_ident op, expr1), expr2) when is_operator_char op.[0] ->
     norm_to_imm
       expr1
       (fun v1 ->

--- a/XML/lib/middleend/infer.ml
+++ b/XML/lib/middleend/infer.ml
@@ -17,7 +17,6 @@ type error =
   | Cannot_unify_constructors of string * string
   | Cannot_unify_quantified
   | Unbound_variable of string
-  | Operator_not_found of string
   | Invalid_let_rec_rhs
   | Invalid_let_rec_lhs
 
@@ -30,7 +29,6 @@ let pprint_err ppf = function
     Format.fprintf ppf "Cannot unify different constructors: %s and %s" c1 c2
   | Cannot_unify_quantified -> Format.fprintf ppf "Cannot unify quantified variable"
   | Unbound_variable id -> Format.fprintf ppf "Unbound variable %s" id
-  | Operator_not_found op -> Format.fprintf ppf "Operator not found: %s" op
   | Invalid_let_rec_rhs ->
     Format.fprintf
       ppf

--- a/XML/lib/middleend/infer.ml
+++ b/XML/lib/middleend/infer.ml
@@ -8,6 +8,7 @@ open Common.Ast.Structure
 open Common.Ast.Pattern
 open Common.Ast.TypeExpr
 open Common.Pprinter
+open Common.Parser
 
 type error =
   | Occurs_check
@@ -307,24 +308,30 @@ and infer_exp env = function
       | [] -> infer_exp new_env exp
     in
     return (newest_env, Type_arrow (typ_p, typ_exp))
-  | Exp_apply (Exp_ident op, Exp_tuple (exp1, exp2, [])) ->
-    (match op with
-     | "*" | "/" | "+" | "-" | "<" | ">" | "=" | "<>" | "<=" | ">=" | "&&" | "||" ->
-       let* new_env, typ1 = infer_exp env exp1 in
-       let* new_env1, typ2 = infer_exp new_env exp2 in
-       let* arg_typ, res_typ =
-         match List.assoc_opt op env with
-         | Some (Type_arrow (arg, Type_arrow (_, res))) -> return (inst arg, inst res)
-         | _ -> fail (Operator_not_found op)
+  | Exp_apply (Exp_apply (Exp_ident op, exp1), exp2) when is_operator_char op.[0] ->
+    let* new_env, typ1 = infer_exp env exp1 in
+    let* new_env1, typ2 = infer_exp new_env exp2 in
+    (match List.assoc_opt op env with
+     | Some op_ty ->
+       let inst_op_ty = inst op_ty in
+       let* res =
+         match inst_op_ty with
+         | Type_arrow (arg1, Type_arrow (arg2, res))
+         | Type_arrow (Type_tuple (arg1, arg2, []), res) ->
+           let* () = unify typ1 arg1 in
+           let* () = unify typ2 arg2 in
+           return res
+         | _ ->
+           let typ_res = newvar () in
+           let tuple_ty = Type_tuple (typ1, typ2, []) in
+           let* () = unify inst_op_ty (Type_arrow (tuple_ty, typ_res)) in
+           return typ_res
        in
-       let* () = unify typ1 arg_typ in
-       let* () = unify typ2 arg_typ in
-       return (new_env1, res_typ)
-     | _ ->
-       let* new_env, typ_op = infer_exp env (Exp_ident op) in
-       let* new_env1, typ_args = infer_exp new_env (Exp_tuple (exp1, exp2, [])) in
+       return (new_env1, res)
+     | None ->
        let typ_res = newvar () in
-       let* () = unify typ_op (Type_arrow (typ_args, typ_res)) in
+       let tuple_ty = Type_tuple (typ1, typ2, []) in
+       let* () = unify typ_res (Type_arrow (tuple_ty, typ_res)) in
        return (new_env1, typ_res))
   | Exp_apply (Exp_ident "-", arg) ->
     let* new_env1, typ_arg = infer_exp env arg in

--- a/XML/lib/middleend/ll.ml
+++ b/XML/lib/middleend/ll.ml
@@ -22,30 +22,29 @@ let get_op_name op =
   else (
     let buf = Buffer.create (String.length op * 5) in
     String.iter
-      (fun c ->
-         match c with
-         | '+' -> Buffer.add_string buf "pls"
-         | '*' -> Buffer.add_string buf "str"
-         | '-' -> Buffer.add_string buf "min"
-         | '/' -> Buffer.add_string buf "sls"
-         | '%' -> Buffer.add_string buf "per"
-         | '=' -> Buffer.add_string buf "eql"
-         | '<' -> Buffer.add_string buf "lss"
-         | '>' -> Buffer.add_string buf "gre"
-         | '&' -> Buffer.add_string buf "amp"
-         | '|' -> Buffer.add_string buf "pip"
-         | '!' -> Buffer.add_string buf "ban"
-         | '?' -> Buffer.add_string buf "que"
-         | '@' -> Buffer.add_string buf "att"
-         | '^' -> Buffer.add_string buf "hat"
-         | '~' -> Buffer.add_string buf "tld"
-         | ':' -> Buffer.add_string buf "cln"
-         | '$' -> Buffer.add_string buf "dol"
-         | '.' -> Buffer.add_string buf "dot"
-         | ',' -> Buffer.add_string buf "com"
-         | c ->
-           Buffer.add_string buf "ch";
-           Buffer.add_char buf c)
+      (function
+        | '+' -> Buffer.add_string buf "pls"
+        | '*' -> Buffer.add_string buf "str"
+        | '-' -> Buffer.add_string buf "min"
+        | '/' -> Buffer.add_string buf "sls"
+        | '%' -> Buffer.add_string buf "per"
+        | '=' -> Buffer.add_string buf "eql"
+        | '<' -> Buffer.add_string buf "lss"
+        | '>' -> Buffer.add_string buf "gre"
+        | '&' -> Buffer.add_string buf "amp"
+        | '|' -> Buffer.add_string buf "pip"
+        | '!' -> Buffer.add_string buf "ban"
+        | '?' -> Buffer.add_string buf "que"
+        | '@' -> Buffer.add_string buf "att"
+        | '^' -> Buffer.add_string buf "hat"
+        | '~' -> Buffer.add_string buf "tld"
+        | ':' -> Buffer.add_string buf "cln"
+        | '$' -> Buffer.add_string buf "dol"
+        | '.' -> Buffer.add_string buf "dot"
+        | ',' -> Buffer.add_string buf "com"
+        | c ->
+          Buffer.add_string buf "ch";
+          Buffer.add_char buf c)
       op;
     Buffer.contents buf)
 ;;

--- a/XML/lib/middleend/ll.ml
+++ b/XML/lib/middleend/ll.ml
@@ -1,21 +1,62 @@
 (** Copyright 2024, Mikhail Gavrilenko,
-    Danila Rudnev-Stepanyan*)
+    Danila Rudnev-Stepanyan, Daniel Vlasenko *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open Common.Ast
+open Common.Parser
 open Anf
 module SSet = Set.Make (String)
 module SMap = Map.Make (String)
 
 type supply = int
+type op_ctx = (ident * ident) list
+
+let op_add ops pair = pair :: ops
+
+(* we rename every (re)defined operator to generate is as a function.
+  on later stages, real operators will have their names unchanged *)
+let get_op_name op =
+  if not (is_operator_char op.[0])
+  then op
+  else (
+    let buf = Buffer.create (String.length op * 5) in
+    String.iter
+      (fun c ->
+         match c with
+         | '+' -> Buffer.add_string buf "pls"
+         | '*' -> Buffer.add_string buf "str"
+         | '-' -> Buffer.add_string buf "min"
+         | '/' -> Buffer.add_string buf "sls"
+         | '%' -> Buffer.add_string buf "per"
+         | '=' -> Buffer.add_string buf "eql"
+         | '<' -> Buffer.add_string buf "lss"
+         | '>' -> Buffer.add_string buf "gre"
+         | '&' -> Buffer.add_string buf "amp"
+         | '|' -> Buffer.add_string buf "pip"
+         | '!' -> Buffer.add_string buf "ban"
+         | '?' -> Buffer.add_string buf "que"
+         | '@' -> Buffer.add_string buf "att"
+         | '^' -> Buffer.add_string buf "hat"
+         | '~' -> Buffer.add_string buf "tld"
+         | ':' -> Buffer.add_string buf "cln"
+         | '$' -> Buffer.add_string buf "dol"
+         | '.' -> Buffer.add_string buf "dot"
+         | ',' -> Buffer.add_string buf "com"
+         | c ->
+           Buffer.add_string buf "ch";
+           Buffer.add_char buf c)
+      op;
+    Buffer.contents buf)
+;;
 
 let fresh_name (base : ident) (n : supply) : ident * supply =
-  base ^ "__ll$" ^ string_of_int n, n + 1
+  get_op_name base ^ "__ll$" ^ string_of_int n, n + 1
 ;;
 
 let fv_im = function
   | Imm_num _ -> SSet.empty
+  | Imm_ident x when is_operator_char x.[0] -> SSet.empty
   | Imm_ident x -> SSet.singleton x
 ;;
 
@@ -58,8 +99,19 @@ and escapes_anf x = function
 
 type ctx = (ident * ident list) SMap.t
 
-let rewrite_app (env : ctx) (f : im_expr) (args : im_expr list) : im_expr * im_expr list =
+let rec rewrite_app (ops : op_ctx) (env : ctx) (f : im_expr) (args : im_expr list)
+  : im_expr * im_expr list
+  =
   match f with
+  | Imm_ident x when is_operator_char x.[0] ->
+    (match List.assoc_opt x ops with
+     | Some y -> rewrite_app ops env (Imm_ident y) args
+     | None ->
+       (match SMap.find_opt x env with
+        | None -> f, args
+        | Some (lf, fvs) ->
+          let fv_atoms = List.map (fun v -> Imm_ident v) fvs in
+          Imm_ident lf, fv_atoms @ args))
   | Imm_ident x ->
     (match SMap.find_opt x env with
      | None -> f, args
@@ -69,21 +121,29 @@ let rewrite_app (env : ctx) (f : im_expr) (args : im_expr list) : im_expr * im_e
   | _ -> f, args
 ;;
 
-let rec lift_anf (env : ctx) (n : supply) (e : anf_expr)
-  : (anf_expr * astructure_item list) * supply
+let rec lift_anf ops (env : ctx) (n : supply) (e : anf_expr)
+  : op_ctx * (anf_expr * astructure_item list) * supply
   =
   match e with
   | Anf_comp_expr ce ->
-    let (ce', defs), n' = lift_comp env n ce in
-    (Anf_comp_expr ce', defs), n'
+    let ops, (ce', defs), n' = lift_comp ops env n ce in
+    ops, (Anf_comp_expr ce', defs), n'
   | Anf_let (rf, x, ce, body) ->
+    let x, n, ops =
+      if is_operator_char x.[0]
+      then (
+        let new_x, n = fresh_name x n in
+        let ops = op_add ops (x, new_x) in
+        new_x, n, ops)
+      else x, n, ops
+    in
     (match ce with
      | Comp_func (ps, fbody) ->
        if escapes_anf x body || escapes_anf x fbody
        then (
-         let (fbody', d1), n1 = lift_anf env n fbody in
-         let (body', d2), n2 = lift_anf env n1 body in
-         (Anf_let (rf, x, Comp_func (ps, fbody'), body'), d1 @ d2), n2)
+         let ops, (fbody', d1), n1 = lift_anf ops env n fbody in
+         let ops, (body', d2), n2 = lift_anf ops env n1 body in
+         ops, (Anf_let (rf, x, Comp_func (ps, fbody'), body'), d1 @ d2), n2)
        else (
          let fvs =
            let all = fv_anf fbody in
@@ -93,12 +153,12 @@ let rec lift_anf (env : ctx) (n : supply) (e : anf_expr)
          in
          let lifted_name, n1 = fresh_name x n in
          let env_body = SMap.add x (lifted_name, fvs) env in
-         let (fbody', defs_body), n2 = lift_anf env_body n1 fbody in
+         let ops, (fbody', defs_body), n2 = lift_anf ops env_body n1 fbody in
          let def_item =
            Anf_str_value
              (Nonrecursive, lifted_name, Anf_comp_expr (Comp_func (fvs @ ps, fbody')))
          in
-         let (body', defs_e2), n3 = lift_anf env_body n2 body in
+         let ops, (body', defs_e2), n3 = lift_anf ops env_body n2 body in
          (* (body', defs_body @ (def_item :: defs_e2)), n3 *)
          let new_body =
            if SSet.mem x (fv_anf body')
@@ -107,16 +167,26 @@ let rec lift_anf (env : ctx) (n : supply) (e : anf_expr)
              Anf_let (Nonrecursive, x, Comp_imm (Imm_ident lifted_name), body')
            else body'
          in
-         (new_body, defs_body @ (def_item :: defs_e2)), n3)
+         ops, (new_body, defs_body @ (def_item :: defs_e2)), n3)
      | Comp_imm (Imm_ident y) ->
+       let y =
+         match List.assoc_opt y ops with
+         | Some z -> z
+         | None -> y
+       in
        (match SMap.find_opt y env with
         | Some (lf, fvs) ->
           let env' = SMap.add x (lf, fvs) env in
-          lift_anf env' n body
+          lift_anf ops env' n body
         | None ->
-          let (body', d2), n' = lift_anf env n body in
-          (Anf_let (rf, x, ce, body'), d2), n')
+          let ops, (body', d2), n' = lift_anf ops env n body in
+          ops, (Anf_let (rf, x, ce, body'), d2), n')
      | Comp_app (Imm_ident lf_id, args) ->
+       let lf_id =
+         match List.assoc_opt lf_id ops with
+         | Some z -> z
+         | None -> lf_id
+       in
        let args_are vs =
          try
            List.for_all2
@@ -150,42 +220,43 @@ let rec lift_anf (env : ctx) (n : supply) (e : anf_expr)
            | Some lf -> SMap.add x (lf, []) env
            | None -> env
          in
-         lift_anf env' n body)
+         lift_anf ops env' n body)
        else (
-         let (ce', d1), n1 = lift_comp env n ce in
-         let (body', d2), n2 = lift_anf env n1 body in
-         (Anf_let (rf, x, ce', body'), d1 @ d2), n2)
+         let ops, (ce', d1), n1 = lift_comp ops env n ce in
+         let ops, (body', d2), n2 = lift_anf ops env n1 body in
+         ops, (Anf_let (rf, x, ce', body'), d1 @ d2), n2)
      | _ ->
-       let (ce', d1), n1 = lift_comp env n ce in
-       let (body', d2), n2 = lift_anf env n1 body in
-       (Anf_let (rf, x, ce', body'), d1 @ d2), n2)
+       let ops, (ce', d1), n1 = lift_comp ops env n ce in
+       let ops, (body', d2), n2 = lift_anf ops env n1 body in
+       ops, (Anf_let (rf, x, ce', body'), d1 @ d2), n2)
 
-and lift_comp (env : ctx) (n : supply) (ce : comp_expr)
-  : (comp_expr * astructure_item list) * supply
+and lift_comp ops (env : ctx) (n : supply) (ce : comp_expr)
+  : op_ctx * (comp_expr * astructure_item list) * supply
   =
   match ce with
-  | Comp_imm _ | Comp_binop _ | Comp_tuple _ | Comp_alloc _ | Comp_load _ -> (ce, []), n
+  | Comp_imm _ | Comp_binop _ | Comp_tuple _ | Comp_alloc _ | Comp_load _ ->
+    ops, (ce, []), n
   | Comp_app (f, args) ->
-    let f', args' = rewrite_app env f args in
-    (Comp_app (f', args'), []), n
+    let f', args' = rewrite_app ops env f args in
+    ops, (Comp_app (f', args'), []), n
   | Comp_branch (c, t, e) ->
-    let (t', dt), n1 = lift_anf env n t in
-    let (e', de), n2 = lift_anf env n1 e in
-    (Comp_branch (c, t', e'), dt @ de), n2
+    let ops, (t', dt), n1 = lift_anf ops env n t in
+    let ops, (e', de), n2 = lift_anf ops env n1 e in
+    ops, (Comp_branch (c, t', e'), dt @ de), n2
   | Comp_func (ps, body) ->
-    let (body', defs), n' = lift_anf env n body in
-    (Comp_func (ps, body'), defs), n'
+    let ops, (body', defs), n' = lift_anf ops env n body in
+    ops, (Comp_func (ps, body'), defs), n'
 ;;
 
-let rec desugar_then_lift (env : ctx) (n : supply) (e : anf_expr)
-  : (anf_expr * astructure_item list) * supply
+let rec desugar_then_lift ops (env : ctx) (n : supply) (e : anf_expr)
+  : op_ctx * (anf_expr * astructure_item list) * supply
   =
   match e with
   | Anf_let
       (Nonrecursive, tmp, Comp_func (ps, fbody), Anf_comp_expr (Comp_imm (Imm_ident tmp')))
     when String.equal tmp tmp' ->
-    let (fbody', d), n' = lift_anf env n fbody in
-    (Anf_comp_expr (Comp_func (ps, fbody')), d), n'
+    let ops, (fbody', d), n' = lift_anf ops env n fbody in
+    ops, (Anf_comp_expr (Comp_func (ps, fbody')), d), n'
   | Anf_let
       ( Nonrecursive
       , tmp
@@ -194,8 +265,8 @@ let rec desugar_then_lift (env : ctx) (n : supply) (e : anf_expr)
     when String.equal tmp tmp' ->
     if escapes_anf x body || escapes_anf x fbody
     then (
-      let (e', d), n' = lift_anf env n e in
-      (e', d), n')
+      let ops, (e', d), n' = lift_anf ops env n e in
+      ops, (e', d), n')
     else (
       let fvs =
         let all = fv_anf fbody in
@@ -206,43 +277,53 @@ let rec desugar_then_lift (env : ctx) (n : supply) (e : anf_expr)
       let env' =
         env |> SMap.add x (lifted_name, fvs) |> SMap.add tmp (lifted_name, fvs)
       in
-      let (fbody', d1), n2 = lift_anf env' n1 fbody in
+      let ops, (fbody', d1), n2 = lift_anf ops env' n1 fbody in
       let def_item =
         Anf_str_value
           (Nonrecursive, lifted_name, Anf_comp_expr (Comp_func (fvs @ ps, fbody')))
       in
-      let (body', d2), n3 = lift_anf env' n2 body in
-      (body', d1 @ (def_item :: d2)), n3)
+      let ops, (body', d2), n3 = lift_anf ops env' n2 body in
+      ops, (body', d1 @ (def_item :: d2)), n3)
   | Anf_let (rf, x, ce, body) ->
-    let (ce', d1), n1 = lift_comp env n ce in
-    let (body', d2), n2 = desugar_then_lift env n1 body in
-    (Anf_let (rf, x, ce', body'), d1 @ d2), n2
+    let ops, (ce', d1), n1 = lift_comp ops env n ce in
+    let ops, (body', d2), n2 = desugar_then_lift ops env n1 body in
+    ops, (Anf_let (rf, x, ce', body'), d1 @ d2), n2
   | Anf_comp_expr ce ->
-    let (ce', d), n' = lift_comp env n ce in
-    (Anf_comp_expr ce', d), n'
+    let ops, (ce', d), n' = lift_comp ops env n ce in
+    ops, (Anf_comp_expr ce', d), n'
 ;;
 
-let lift_item (it : astructure_item) (n : supply)
-  : (astructure_item * astructure_item list) * supply
+let lift_item ops (it : astructure_item) (n : supply)
+  : op_ctx * (astructure_item * astructure_item list) * supply
   =
   match it with
   | Anf_str_eval e ->
-    let (e1, d1), n1 = desugar_then_lift SMap.empty n e in
-    let (e2, d2), n2 = lift_anf SMap.empty n1 e1 in
-    (Anf_str_eval e2, d1 @ d2), n2
+    let ops, (e1, d1), n1 = desugar_then_lift ops SMap.empty n e in
+    let ops, (e2, d2), n2 = lift_anf ops SMap.empty n1 e1 in
+    ops, (Anf_str_eval e2, d1 @ d2), n2
   | Anf_str_value (rf, name, e) ->
-    let (e1, d1), n1 = desugar_then_lift SMap.empty n e in
-    let (e2, d2), n2 = lift_anf SMap.empty n1 e1 in
-    (Anf_str_value (rf, name, e2), d1 @ d2), n2
+    let is_operator = String.length name > 0 && is_operator_char name.[0] in
+    let name, n, ops, e =
+      if is_operator
+      then (
+        let fresh_op_name, n' = fresh_name name n in
+        let ops' = op_add ops (name, fresh_op_name) in
+        fresh_op_name, n', ops', e)
+      else name, n, ops, e
+    in
+    let ops, (e1, d1), n1 = desugar_then_lift ops SMap.empty n e in
+    let ops, (e2, d2), n2 = lift_anf ops SMap.empty n1 e1 in
+    ops, (Anf_str_value (rf, name, e2), d1 @ d2), n2
 ;;
 
 let lambda_lift_program (p : aprogram) : aprogram =
-  let (items_rev, defs), _ =
+  let ops = [] in
+  let (items_rev, defs), _, _ =
     List.fold_left
-      (fun ((acc, dacc), n) it ->
-         let (it', d), n' = lift_item it n in
-         (it' :: acc, dacc @ d), n')
-      (([], []), 1)
+      (fun ((acc, dacc), ops, n) it ->
+         let ops, (it', d), n' = lift_item ops it n in
+         (it' :: acc, dacc @ d), ops, n')
+      (([], []), ops, 1)
       p
   in
   List.rev items_rev @ defs

--- a/XML/lib/middleend/pprinter.ml
+++ b/XML/lib/middleend/pprinter.ml
@@ -5,6 +5,7 @@
 open Format
 open Common.Ast
 open Anf
+open Common.Parser
 
 let pp_list ~sep pp ppf xs =
   let pp_sep ppf () = Format.fprintf ppf "%s@ " sep in
@@ -75,7 +76,9 @@ let print_anf_expr ppf e = pp_anf_expr_impl ~parens:false ppf e
 let print_anf_structure_item ppf = function
   | Anf_str_eval e -> fprintf ppf "@[<hov 2>%a@];;" print_anf_expr e
   | Anf_str_value (rf, name, e) ->
-    fprintf ppf "@[<hov 2>%a %s = %a@];;" pp_rec_flag rf name print_anf_expr e
+    if is_operator_char name.[0]
+    then fprintf ppf "@[<hov 2>%a (%s) = %a@];;" pp_rec_flag rf name print_anf_expr e
+    else fprintf ppf "@[<hov 2>%a %s = %a@];;" pp_rec_flag rf name print_anf_expr e
 ;;
 
 let print_anf_program ppf (prog : aprogram) =

--- a/XML/lib/middleend/pprinter.ml
+++ b/XML/lib/middleend/pprinter.ml
@@ -30,6 +30,8 @@ let pp_app ppf (f, args) =
 let rec pp_anf_expr_impl ~parens ppf (e : anf_expr) =
   let pp_comp ppf = function
     | Comp_imm imm -> pp_immediate ppf imm
+    | Comp_app (Imm_ident op, [ arg1; arg2 ]) when is_operator_char op.[0] ->
+      fprintf ppf "(%a %s %a)" pp_immediate arg1 op pp_immediate arg2
     | Comp_binop (op, a, b) -> fprintf ppf "(%a %s %a)" pp_immediate a op pp_immediate b
     | Comp_app (f, args) -> pp_app ppf (f, args)
     | Comp_branch (c, t, e) ->

--- a/XML/lib/middleend/pprinter.ml
+++ b/XML/lib/middleend/pprinter.ml
@@ -77,10 +77,10 @@ let print_anf_expr ppf e = pp_anf_expr_impl ~parens:false ppf e
 
 let print_anf_structure_item ppf = function
   | Anf_str_eval e -> fprintf ppf "@[<hov 2>%a@];;" print_anf_expr e
+  | Anf_str_value (rf, name, e) when is_operator_char name.[0] ->
+    fprintf ppf "@[<hov 2>%a (%s) = %a@];;" pp_rec_flag rf name print_anf_expr e
   | Anf_str_value (rf, name, e) ->
-    if is_operator_char name.[0]
-    then fprintf ppf "@[<hov 2>%a (%s) = %a@];;" pp_rec_flag rf name print_anf_expr e
-    else fprintf ppf "@[<hov 2>%a %s = %a@];;" pp_rec_flag rf name print_anf_expr e
+    fprintf ppf "@[<hov 2>%a %s = %a@];;" pp_rec_flag rf name print_anf_expr e
 ;;
 
 let print_anf_program ppf (prog : aprogram) =

--- a/XML/many_tests/cc.t
+++ b/XML/many_tests/cc.t
@@ -4,7 +4,7 @@
   > let add x = x + c in
   > let mul x = x * c in
   > print_int (add 3 + mul 4)
-  let main = (let c = 2 in (let add = ((fun c x -> x + c) c) in (let mul = ((fun c x -> x * c) c) in (print_int (add c) 3 + (mul c) 4))));;
+  let main = (let c = 2 in (let add = ((fun c x -> x + c) c) in (let mul = ((fun c x -> x * c) c) in (print_int ((add c) 3) + ((mul c) 4)))));;
   
   
   $ dune exec ./../bin/XML.exe -- --cc <<EOF
@@ -24,13 +24,13 @@
   
   let fresh_2 = (fun p1 k p2 -> (k p1 + p2));;
   
-  let fresh_1 = (fun n k fib p1 -> (fib n - 2) ((fresh_2 p1) k));;
+  let fresh_1 = (fun n k fib p1 -> ((fib n - 2) ((fresh_2 p1) k)));;
   
   let rec fib = (fun n k -> (if n < 2
     then (k n)
-    else (fib n - 1) (((fresh_1 n) k) fib)));;
+    else ((fib n - 1) ((fresh_1 n) k) fib)));;
   
-  let main = (let z = (print_int (fib 6) id) in 0);;
+  let main = (let z = (print_int ((fib 6) id)) in 0);;
   
   
 

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -12,9 +12,8 @@
     sd ra, 80(sp)
     sd s0, 72(sp)
     addi s0, sp, 72
-    mv t0, a0
     li t1, 1
-    bne t0, t1, else_0
+    bne a0, t1, else_0
     li t0, 3
     j endif_1
   else_0:
@@ -37,7 +36,6 @@
     add t0, t0, t0
     addi t0, t0, 1
   endif_1:
-    sd t0, -40(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -53,7 +51,6 @@
     li a0, 9
     call fac
     call print_int
-    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -79,9 +76,8 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    mv t0, a0
     li t1, 3
-    blt t1, t0, else_0
+    blt t1, a0, else_0
     mv t0, a0
     j endif_1
   else_0:
@@ -112,7 +108,6 @@
     add t0, t0, t1
     addi t0, t0, -1
   endif_1:
-    sd t0, -56(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -128,7 +123,6 @@
     li a0, 13
     call fib
     call print_int
-    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -180,7 +174,6 @@
     ld a0, 8(sp)
     addi sp, sp, 16
   endif_1:
-    sd t0, -24(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -225,7 +218,6 @@
   endif_7:
     mv a0, t0
     call large
-    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -254,10 +246,8 @@
     sd s0, 48(sp)
     addi s0, sp, 48
     mv t0, a0
-    mv t1, a1
-    add t0, t0, t1
+    add t0, t0, a1
     addi t0, t0, -1
-    sd t0, -8(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -278,7 +268,6 @@
     call apply1
     mv t0, a0
     addi sp, sp, 8
-    sd t0, -8(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -295,7 +284,6 @@
     li a1, 11
     call apply1
     call print_int
-    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -338,10 +326,9 @@
     add t0, t0, t0
     addi t0, t0, 1
     sd t0, -8(s0)
-    addi sp, sp, -16
-    sd a2, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a2, 16(sp)
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     mv t0, a1
@@ -354,7 +341,6 @@
     ld a0, 16(sp)
     ld a2, 24(sp)
     addi sp, sp, 32
-    sd t0, -16(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -365,9 +351,8 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    mv t0, a0
     li t1, 3
-    bne t0, t1, else_0
+    bne a0, t1, else_0
     addi sp, sp, -16
     sd a0, 8(sp)
     sd a1, 0(sp)
@@ -400,10 +385,9 @@
     ld a0, 16(sp)
     addi sp, sp, 24
     sd t0, -24(s0)
-    addi sp, sp, -16
-    sd a0, 8(sp)
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a0, 16(sp)
+    sd a1, 8(sp)
     sd a0, 0(sp)
     la a0, fresh_1
     li a1, 3
@@ -438,7 +422,6 @@
     ld a0, 8(sp)
     addi sp, sp, 16
   endif_1:
-    sd t0, -56(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -469,7 +452,6 @@
     mv a1, t1
     call apply1
     call print_int
-    sd a0, -24(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -504,14 +486,12 @@
     sd s0, 56(sp)
     addi s0, sp, 56
     mv t0, a0
-    mv t1, a2
-    add t0, t0, t1
+    add t0, t0, a2
     addi t0, t0, -1
     sd t0, -8(s0)
-    addi sp, sp, -16
-    sd a2, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a2, 16(sp)
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     mv t0, a1
@@ -524,7 +504,6 @@
     ld a0, 16(sp)
     ld a2, 24(sp)
     addi sp, sp, 32
-    sd t0, -16(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -537,10 +516,9 @@
     addi s0, sp, 80
     addi t0, a0, -4
     sd t0, -8(s0)
-    addi sp, sp, -16
-    sd a3, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -16
+    addi sp, sp, -32
+    sd a3, 24(sp)
+    sd a0, 16(sp)
     sd a1, 8(sp)
     sd a2, 0(sp)
     mv t0, a2
@@ -555,13 +533,11 @@
     ld a3, 24(sp)
     addi sp, sp, 32
     sd t0, -16(s0)
-    addi sp, sp, -16
-    sd a3, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -16
-    sd a1, 8(sp)
-    sd a2, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -40
+    sd a3, 32(sp)
+    sd a0, 24(sp)
+    sd a1, 16(sp)
+    sd a2, 8(sp)
     sd a3, 0(sp)
     la a0, fresh_2
     li a1, 3
@@ -575,10 +551,9 @@
     ld a3, 32(sp)
     addi sp, sp, 40
     sd t0, -24(s0)
-    addi sp, sp, -16
-    sd a3, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -16
+    addi sp, sp, -32
+    sd a3, 24(sp)
+    sd a0, 16(sp)
     sd a1, 8(sp)
     sd a2, 0(sp)
     ld a0, -24(s0)
@@ -590,10 +565,9 @@
     ld a3, 24(sp)
     addi sp, sp, 32
     sd t0, -32(s0)
-    addi sp, sp, -16
-    sd a3, 8(sp)
-    sd a0, 0(sp)
-    addi sp, sp, -16
+    addi sp, sp, -32
+    sd a3, 24(sp)
+    sd a0, 16(sp)
     sd a1, 8(sp)
     sd a2, 0(sp)
     ld t0, -16(s0)
@@ -607,7 +581,6 @@
     ld a0, 16(sp)
     ld a3, 24(sp)
     addi sp, sp, 32
-    sd t0, -40(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -618,9 +591,8 @@
     sd ra, 104(sp)
     sd s0, 96(sp)
     addi s0, sp, 96
-    mv t0, a0
     li t1, 5
-    ble t1, t0, else_0
+    ble t1, a0, else_0
     addi sp, sp, -16
     sd a0, 8(sp)
     sd a1, 0(sp)
@@ -653,10 +625,9 @@
     ld a0, 16(sp)
     addi sp, sp, 24
     sd t0, -24(s0)
-    addi sp, sp, -16
-    sd a0, 8(sp)
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a0, 16(sp)
+    sd a1, 8(sp)
     sd a0, 0(sp)
     la a0, fresh_1
     li a1, 4
@@ -707,7 +678,6 @@
     ld a0, 8(sp)
     addi sp, sp, 16
   endif_1:
-    sd t0, -64(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -738,7 +708,6 @@
     mv a1, t1
     call apply1
     call print_int
-    sd a0, -32(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -770,7 +739,6 @@
   else_0:
     mv t0, a0
   endif_1:
-    sd t0, -16(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -781,10 +749,9 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    addi sp, sp, -16
-    sd a2, 8(sp)
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a2, 16(sp)
+    sd a1, 8(sp)
     sd a0, 0(sp)
     addi sp, sp, -8
     call print_int
@@ -797,8 +764,7 @@
     addi sp, sp, -16
     sd a2, 8(sp)
     sd a1, 0(sp)
-    mv t0, a1
-    mv a0, t0
+    mv a0, a1
     call print_int
     mv t0, a0
     ld a1, 0(sp)
@@ -808,13 +774,11 @@
     addi sp, sp, -8
     sd a2, 0(sp)
     addi sp, sp, -8
-    mv t0, a2
-    mv a0, t0
+    mv a0, a2
     call print_int
     mv t0, a0
     ld a2, 8(sp)
     addi sp, sp, 16
-    sd t0, -48(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -826,26 +790,19 @@
     sd s0, 112(sp)
     addi s0, sp, 112
     mv t0, a0
-    mv t1, a1
-    add t0, t0, t1
+    add t0, t0, a1
     addi t0, t0, -1
-    mv t1, a2
-    add t0, t0, t1
+    add t0, t0, a2
     addi t0, t0, -1
-    mv t1, a3
-    add t0, t0, t1
+    add t0, t0, a3
     addi t0, t0, -1
-    mv t1, a4
-    add t0, t0, t1
+    add t0, t0, a4
     addi t0, t0, -1
-    mv t1, a5
-    add t0, t0, t1
+    add t0, t0, a5
     addi t0, t0, -1
-    mv t1, a6
-    add t0, t0, t1
+    add t0, t0, a6
     addi t0, t0, -1
-    mv t1, a7
-    add t0, t0, t1
+    add t0, t0, a7
     addi t0, t0, -1
     ld t1, 16(s0)
     add t0, t0, t1
@@ -853,7 +810,6 @@
     ld t1, 24(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -72(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -902,7 +858,6 @@
     call apply1
     li a1, 201
     call apply1
-    sd a0, -144(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -956,7 +911,6 @@
     sd t1, 8(t2)
     ld t0, 0(sp)
     addi sp, sp, 8
-    sd t0, -8(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -997,7 +951,6 @@
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1037,9 +990,7 @@
     addi sp, sp, 8
     mv t0, a0
     ld a0, 0(sp)
-    addi sp, sp, 8
     sd t0, -24(s0)
-    addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
     ld a0, -8(s0)
@@ -1067,7 +1018,6 @@
     sd t1, 8(t2)
     ld t0, 0(sp)
     addi sp, sp, 8
-    sd t0, -48(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -1107,7 +1057,6 @@
     sd a0, -72(s0)
     ld a0, -56(s0)
     call print_int
-    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1182,7 +1131,6 @@
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    sd a0, -88(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1211,9 +1159,8 @@
     sd ra, 112(sp)
     sd s0, 104(sp)
     addi s0, sp, 104
-    mv t0, a0
     li t1, 1
-    bne t0, t1, else_0
+    bne a0, t1, else_0
     li t0, 1
     j endif_1
   else_0:
@@ -1227,9 +1174,7 @@
     addi sp, sp, 8
     mv t0, a0
     ld a0, 0(sp)
-    addi sp, sp, 8
     sd t0, -32(s0)
-    addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
     ld a0, -16(s0)
@@ -1238,9 +1183,7 @@
     addi sp, sp, 8
     mv t0, a0
     ld a0, 0(sp)
-    addi sp, sp, 8
     sd t0, -48(s0)
-    addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
     ld a0, -48(s0)
@@ -1254,7 +1197,6 @@
     add t0, t0, t1
     addi t0, t0, -1
   endif_1:
-    sd t0, -72(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -1317,7 +1259,6 @@
     mv a0, t0
     call sum_list
     call print_int
-    sd a0, -48(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1432,7 +1373,6 @@
     li a1, 9
     call field
     call print_int
-    sd a0, -192(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1489,7 +1429,6 @@
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    sd a0, -72(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1572,7 +1511,6 @@
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    sd a0, -112(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1610,9 +1548,7 @@
     addi sp, sp, 8
     mv t0, a0
     ld a0, 0(sp)
-    addi sp, sp, 8
     sd t0, -24(s0)
-    addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
     ld a0, -8(s0)
@@ -1627,7 +1563,6 @@
     ld t1, -40(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -48(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -1658,7 +1593,6 @@
     mv a0, t0
     call sum_pair
     call print_int
-    sd a0, -32(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1689,9 +1623,8 @@
     sd ra, 88(sp)
     sd s0, 80(sp)
     addi s0, sp, 80
-    mv t0, a0
     li t1, 1
-    bne t0, t1, else_0
+    bne a0, t1, else_0
     mv t0, a1
     j endif_1
   else_0:
@@ -1733,10 +1666,9 @@
     addi t2, t2, 16
     sd t1, 8(t2)
     ld t0, 0(sp)
-    addi sp, sp, 8
     sd t0, -32(s0)
-    addi sp, sp, -16
-    sd a0, 8(sp)
+    sd a0, 0(sp)
+    addi sp, sp, -8
     sd a1, 0(sp)
     ld t0, -24(s0)
     ld t1, -32(s0)
@@ -1748,7 +1680,6 @@
     ld a0, 8(sp)
     addi sp, sp, 16
   endif_1:
-    sd t0, -48(s0)
     mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -1789,7 +1720,6 @@
     sd a0, -80(s0)
     ld a0, -56(s0)
     call print_int
-    sd a0, -88(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1816,4 +1746,3 @@
   GC    allocations: 30002
   =================
   1
-

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -1203,6 +1203,98 @@
   >   let p = make_pair 10 20 in
   >   let (a, b) = p in
   >   print_int (a + b)
+  $ cat tuple_return.s
+  .section .text
+  .global main
+  .type main, @function
+  make_pair:
+    addi sp, sp, -64
+    sd ra, 56(sp)
+    sd s0, 48(sp)
+    addi s0, sp, 48
+    addi sp, sp, -8
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 16(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    mv t1, a0
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    mv t1, a1
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld a0, -8(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -136
+    sd ra, 128(sp)
+    sd s0, 120(sp)
+    addi s0, sp, 120
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    li t1, 21
+    sd t1, 0(sp)
+    la a0, make_pair
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    li t1, 41
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld a0, -32(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -48(s0)
+    ld t1, -64(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -80(s0)
+    ld a0, -80(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_return.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1218,6 +1310,117 @@
   >   let p2 = swap p1 in
   >   let (x, y) = p2 in
   >   print_int x
+  $ cat tuple_swap.s
+  .section .text
+  .global main
+  .type main, @function
+  swap:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    li a0, 2
+    call create_tuple
+    sd a0, 8(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld t1, -40(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -24(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -136
+    sd ra, 128(sp)
+    sd s0, 120(sp)
+    addi s0, sp, 120
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 3
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call swap
+    mv t0, a0
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld a0, -40(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -72(s0)
+    ld t0, -56(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -80(s0)
+    ld a0, -80(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_swap.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1231,6 +1434,86 @@
   >   let t = (f 10, f 20) in
   >   let (a, b) = t in
   >   print_int (a + b)
+  $ cat tuple_order.s
+  .section .text
+  .global main
+  .type main, @function
+  f:
+    addi sp, sp, -56
+    sd ra, 48(sp)
+    sd s0, 40(sp)
+    addi s0, sp, 40
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -144
+    sd ra, 136(sp)
+    sd s0, 128(sp)
+    addi s0, sp, 128
+    li a0, 5120
+    call rt_init
+    li t0, 21
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call f
+    mv t0, a0
+    sd t0, -8(s0)
+    li t0, 41
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call f
+    mv t0, a0
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -16(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld a0, -40(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -72(s0)
+    ld t0, -56(s0)
+    ld t1, -72(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -88(s0)
+    ld a0, -88(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_order.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1245,6 +1528,148 @@
   > let main =
   >   let lst = (10, (20, (30, 0))) in
   >   print_int (sum_list lst)
+  $ cat tuple_linked_list.s
+  .section .text
+  .global main
+  .type main, @function
+  sum_list:
+    addi sp, sp, -120
+    sd ra, 112(sp)
+    sd s0, 104(sp)
+    addi s0, sp, 104
+    mv t0, a0
+    li t1, 1
+    xor t2, t0, t1
+    seqz t0, t2
+    beq t0, zero, else_0
+    li t0, 1
+    j endif_1
+  else_0:
+    mv t0, a0
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -16(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -16(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -48(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld t0, -48(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_list
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -56(s0)
+    ld t0, -32(s0)
+    ld t1, -56(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+  endif_1:
+    sd t0, -72(s0)
+    ld a0, -72(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 61
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 1
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -16(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_list
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_linked_list.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1255,6 +1680,128 @@
   >   let t = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) in
   >   let (a, b, c, d, e, f, g, h, i, j) = t in
   >   print_int j
+  $ cat tuple_large.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -248
+    sd ra, 240(sp)
+    sd s0, 232(sp)
+    addi s0, sp, 232
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 10
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 3
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    li t1, 7
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 16(t2)
+    li t1, 9
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 24(t2)
+    li t1, 11
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 32(t2)
+    li t1, 13
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 40(t2)
+    li t1, 15
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 48(t2)
+    li t1, 17
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 56(t2)
+    li t1, 19
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 64(t2)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 72(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld a0, -24(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -40(s0)
+    ld a0, -24(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld a0, -24(s0)
+    li a1, 2
+    call field
+    mv t0, a0
+    sd t0, -72(s0)
+    ld a0, -24(s0)
+    li a1, 3
+    call field
+    mv t0, a0
+    sd t0, -88(s0)
+    ld a0, -24(s0)
+    li a1, 4
+    call field
+    mv t0, a0
+    sd t0, -104(s0)
+    ld a0, -24(s0)
+    li a1, 5
+    call field
+    mv t0, a0
+    sd t0, -120(s0)
+    ld a0, -24(s0)
+    li a1, 6
+    call field
+    mv t0, a0
+    sd t0, -136(s0)
+    ld a0, -24(s0)
+    li a1, 7
+    call field
+    mv t0, a0
+    sd t0, -152(s0)
+    ld a0, -24(s0)
+    li a1, 8
+    call field
+    mv t0, a0
+    sd t0, -168(s0)
+    ld a0, -24(s0)
+    li a1, 9
+    call field
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -192(s0)
+    ld a0, -192(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_large.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1265,6 +1812,61 @@
   >   let t = (10, 20) in
   >   let (a, b) = t in
   >   print_int (a + b)
+  $ cat tuple_basic.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -128
+    sd ra, 120(sp)
+    sd s0, 112(sp)
+    addi s0, sp, 112
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld a0, -24(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -40(s0)
+    ld a0, -24(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld t0, -40(s0)
+    ld t1, -56(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -72(s0)
+    ld a0, -72(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_basic.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1275,6 +1877,91 @@
   >   let complex = (100, (20, 3)) in
   >   let (a, (b, c)) = complex in
   >   print_int (a + b + c)
+  $ cat tuple_nested.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -168
+    sd ra, 160(sp)
+    sd s0, 152(sp)
+    addi s0, sp, 152
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 7
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 201
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld a0, -32(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld a0, -56(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -72(s0)
+    ld a0, -56(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -88(s0)
+    ld t0, -48(s0)
+    ld t1, -72(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    ld t1, -88(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -112(s0)
+    ld a0, -112(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_nested.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
@@ -1288,6 +1975,91 @@
   > let main =
   >   let p = (40, 2) in
   >   print_int (sum_pair p)
+  $ cat tuple_arg.s
+  .section .text
+  .global main
+  .type main, @function
+  sum_pair:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld t0, -24(s0)
+    ld t1, -40(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -88
+    sd ra, 80(sp)
+    sd s0, 72(sp)
+    addi s0, sp, 72
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 81
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_pair
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
   $ riscv64-linux-gnu-as -march=rv64gc tuple_arg.s -o temp.o
   $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -14,9 +14,7 @@
     addi s0, sp, 72
     mv t0, a0
     li t1, 1
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_0
+    bne t0, t1, else_0
     li t0, 3
     j endif_1
   else_0:
@@ -93,9 +91,7 @@
     addi s0, sp, 88
     mv t0, a0
     li t1, 3
-    slt t2, t1, t0
-    seqz t0, t2
-    beq t0, zero, else_0
+    blt t1, t0, else_0
     mv t0, a0
     j endif_1
   else_0:
@@ -189,9 +185,7 @@
     addi s0, sp, 56
     li t0, 1
     mv t1, a0
-    xor t2, t0, t1
-    snez t0, t2
-    beq t0, zero, else_0
+    beq t0, a0, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -230,9 +224,7 @@
     call rt_init
     li t0, 1
     li t1, 3
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_2
+    bne t0, t1, else_2
     li t0, 1
     li t1, 3
     xor t2, t0, t1
@@ -256,9 +248,7 @@
     li t0, 3
   endif_5:
     li t1, 3
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_6
+    bne t0, t1, else_6
     li t0, 1
     j endif_7
   else_6:
@@ -424,9 +414,7 @@
     addi s0, sp, 88
     mv t0, a0
     li t1, 3
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_0
+    bne t0, t1, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -745,8 +733,7 @@
     addi s0, sp, 96
     mv t0, a0
     li t1, 5
-    slt t0, t0, t1
-    beq t0, zero, else_0
+    ble t1, t0, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -923,9 +910,7 @@
     addi s0, sp, 56
     li t0, 3
     li t1, 3
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_0
+    bne t0, t1, else_0
     mv t0, a0
     j endif_1
   else_0:
@@ -1461,9 +1446,7 @@
     addi s0, sp, 104
     mv t0, a0
     li t1, 1
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_0
+    bne t0, t1, else_0
     li t0, 1
     j endif_1
   else_0:
@@ -1985,9 +1968,7 @@
     addi s0, sp, 80
     mv t0, a0
     li t1, 1
-    xor t2, t0, t1
-    seqz t0, t2
-    beq t0, zero, else_0
+    bne t0, t1, else_0
     mv t0, a1
     j endif_1
   else_0:

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -19,9 +19,7 @@
     j endif_1
   else_0:
     mv t0, a0
-    li t1, 3
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -58,12 +56,9 @@
     li t0, 9
     mv a0, t0
     call fac
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -96,9 +91,7 @@
     j endif_1
   else_0:
     mv t0, a0
-    li t1, 3
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -112,9 +105,7 @@
     addi sp, sp, 8
     sd t0, -24(s0)
     mv t0, a0
-    li t1, 5
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -4
     sd t0, -32(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -148,12 +139,9 @@
     li t0, 13
     mv a0, t0
     call fib
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -258,7 +246,6 @@
     call large
     mv t0, a0
     sd t0, -80(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -307,9 +294,7 @@
     la a0, simplesum
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -328,17 +313,12 @@
     li a0, 5120
     call rt_init
     call partialapp_sum
-    mv t0, a0
     li t1, 11
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -432,9 +412,7 @@
     j endif_1
   else_0:
     mv t0, a0
-    li t1, 3
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -446,9 +424,7 @@
     la a0, fac_cps
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -468,9 +444,7 @@
     la a0, fresh_1
     li a1, 3
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -485,9 +459,7 @@
     addi sp, sp, -8
     sd a1, 0(sp)
     ld t0, -32(s0)
-    mv t1, a1
     mv a0, t0
-    mv a1, t1
     call apply1
     mv t0, a0
     ld a1, 0(sp)
@@ -529,9 +501,7 @@
     la a0, fac_cps
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -543,8 +513,6 @@
     mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -24(s0)
@@ -618,9 +586,7 @@
     sd s0, 80(sp)
     addi s0, sp, 80
     mv t0, a0
-    li t1, 5
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -4
     sd t0, -8(s0)
     addi sp, sp, -8
     sd a3, 0(sp)
@@ -659,9 +625,7 @@
     la a0, fresh_2
     li a1, 3
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -684,9 +648,7 @@
     addi sp, sp, -8
     sd a2, 0(sp)
     ld t0, -24(s0)
-    mv t1, a1
     mv a0, t0
-    mv a1, t1
     call apply1
     mv t0, a0
     ld a2, 0(sp)
@@ -751,9 +713,7 @@
     j endif_1
   else_0:
     mv t0, a0
-    li t1, 3
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -765,9 +725,7 @@
     la a0, fib
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -787,9 +745,7 @@
     la a0, fresh_1
     li a1, 4
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -804,9 +760,7 @@
     addi sp, sp, -8
     sd a1, 0(sp)
     ld t0, -32(s0)
-    mv t1, a1
     mv a0, t0
-    mv a1, t1
     call apply1
     mv t0, a0
     ld a1, 0(sp)
@@ -866,9 +820,7 @@
     la a0, fib
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -880,8 +832,6 @@
     mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -32(s0)
@@ -934,8 +884,6 @@
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -1024,83 +972,51 @@
     la a0, test10
     li a1, 10
     call alloc_closure
-    mv t0, a0
-    mv a0, t0
     call wrap
-    mv t0, a0
     li t1, 3
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 21
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 201
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 2001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 20001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 200001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 2000001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 20000001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 200000001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 2000000001
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -104(s0)
     la a0, test3
     li a1, 3
     call alloc_closure
-    mv t0, a0
-    mv a0, t0
     call wrap
-    mv t0, a0
     li t1, 3
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 21
-    mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
     li t1, 201
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -1137,8 +1053,7 @@
     sd ra, 56(sp)
     sd s0, 48(sp)
     addi s0, sp, 48
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     sd a1, 0(sp)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -1180,9 +1095,7 @@
     la a0, make_pair
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -1193,7 +1106,6 @@
     call apply1
     mv t0, a0
     sd t0, -32(s0)
-    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1211,7 +1123,6 @@
     call print_int
     mv t0, a0
     sd t0, -80(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1265,8 +1176,7 @@
     ld a0, 0(sp)
     addi sp, sp, 8
     sd t0, -40(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     sd a0, 0(sp)
     li a0, 2
     call create_tuple
@@ -1296,8 +1206,7 @@
     addi s0, sp, 120
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1316,7 +1225,6 @@
     call swap
     mv t0, a0
     sd t0, -40(s0)
-    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1331,7 +1239,6 @@
     call print_int
     mv t0, a0
     sd t0, -80(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1380,8 +1287,7 @@
     call f
     mv t0, a0
     sd t0, -16(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1415,7 +1321,6 @@
     call print_int
     mv t0, a0
     sd t0, -88(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1503,8 +1408,7 @@
     addi s0, sp, 88
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1520,8 +1424,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -8(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1537,8 +1440,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -16(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1555,12 +1457,9 @@
     addi sp, sp, 8
     mv a0, t0
     call sum_list
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -48(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1587,8 +1486,7 @@
     addi s0, sp, 232
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 10
     call create_tuple
     addi sp, sp, 8
@@ -1684,12 +1582,9 @@
     ld a0, -24(s0)
     li a1, 9
     call field
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -192(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1716,8 +1611,7 @@
     addi s0, sp, 112
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1751,7 +1645,6 @@
     call print_int
     mv t0, a0
     sd t0, -72(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1778,8 +1671,7 @@
     addi s0, sp, 152
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1795,8 +1687,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -8(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1822,7 +1713,6 @@
     call field
     mv t0, a0
     sd t0, -56(s0)
-    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1843,7 +1733,6 @@
     call print_int
     mv t0, a0
     sd t0, -112(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1912,8 +1801,7 @@
     addi s0, sp, 72
     li a0, 5120
     call rt_init
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     li a0, 2
     call create_tuple
     addi sp, sp, 8
@@ -1930,12 +1818,9 @@
     addi sp, sp, 8
     mv a0, t0
     call sum_pair
-    mv t0, a0
-    mv a0, t0
     call print_int
     mv t0, a0
     sd t0, -32(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1973,9 +1858,7 @@
     j endif_1
   else_0:
     mv t0, a0
-    li t1, 3
-    sub t0, t0, t1
-    addi t0, t0, 1
+    addi t0, t0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -1987,9 +1870,7 @@
     la a0, make_list
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -1999,8 +1880,7 @@
     ld a0, 0(sp)
     addi sp, sp, 8
     sd t0, -24(s0)
-    addi sp, sp, -8
-    addi sp, sp, -8
+    addi sp, sp, -16
     sd a0, 0(sp)
     addi sp, sp, -8
     sd a1, 0(sp)
@@ -2061,9 +1941,7 @@
     la a0, make_list
     li a1, 2
     call alloc_closure
-    mv t0, a0
     ld t1, 0(sp)
-    mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
@@ -2074,7 +1952,6 @@
     call apply1
     mv t0, a0
     sd t0, -40(s0)
-    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -2092,7 +1969,6 @@
     call print_int
     mv t0, a0
     sd t0, -88(s0)
-    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -53,8 +53,7 @@
     addi s0, sp, 56
     li a0, 5120
     call rt_init
-    li t0, 9
-    mv a0, t0
+    li a0, 9
     call fac
     call print_int
     mv t0, a0
@@ -136,8 +135,7 @@
     addi s0, sp, 56
     li a0, 5120
     call rt_init
-    li t0, 13
-    mv a0, t0
+    li a0, 13
     call fib
     call print_int
     mv t0, a0
@@ -177,8 +175,7 @@
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    li t0, 1
-    mv a0, t0
+    li a0, 1
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -189,8 +186,7 @@
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    li t0, 3
-    mv a0, t0
+    li a0, 3
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -219,8 +215,7 @@
     seqz t0, t2
     j endif_3
   else_2:
-    li t0, 85
-    mv a0, t0
+    li a0, 85
     call print_int
     mv t0, a0
     sd t0, -24(s0)
@@ -313,8 +308,7 @@
     li a0, 5120
     call rt_init
     call partialapp_sum
-    li t1, 11
-    mv a1, t1
+    li a1, 11
     call apply1
     call print_int
     mv t0, a0
@@ -973,35 +967,25 @@
     li a1, 10
     call alloc_closure
     call wrap
-    li t1, 3
-    mv a1, t1
+    li a1, 3
     call apply1
-    li t1, 21
-    mv a1, t1
+    li a1, 21
     call apply1
-    li t1, 201
-    mv a1, t1
+    li a1, 201
     call apply1
-    li t1, 2001
-    mv a1, t1
+    li a1, 2001
     call apply1
-    li t1, 20001
-    mv a1, t1
+    li a1, 20001
     call apply1
-    li t1, 200001
-    mv a1, t1
+    li a1, 200001
     call apply1
-    li t1, 2000001
-    mv a1, t1
+    li a1, 2000001
     call apply1
-    li t1, 20000001
-    mv a1, t1
+    li a1, 20000001
     call apply1
-    li t1, 200000001
-    mv a1, t1
+    li a1, 200000001
     call apply1
-    li t1, 2000000001
-    mv a1, t1
+    li a1, 2000000001
     call apply1
     call print_int
     mv t0, a0
@@ -1010,14 +994,11 @@
     li a1, 3
     call alloc_closure
     call wrap
-    li t1, 3
-    mv a1, t1
+    li a1, 3
     call apply1
-    li t1, 21
-    mv a1, t1
+    li a1, 21
     call apply1
-    li t1, 201
-    mv a1, t1
+    li a1, 201
     call apply1
     mv t0, a0
     sd t0, -144(s0)
@@ -1277,13 +1258,11 @@
     addi s0, sp, 128
     li a0, 5120
     call rt_init
-    li t0, 21
-    mv a0, t0
+    li a0, 21
     call f
     mv t0, a0
     sd t0, -8(s0)
-    li t0, 41
-    mv a0, t0
+    li a0, 41
     call f
     mv t0, a0
     sd t0, -16(s0)

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -16,8 +16,6 @@
     li t1, 1
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     li t0, 3
     j endif_1
@@ -48,8 +46,6 @@
     mul t0, t2, t3
     add t0, t0, t0
     addi t0, t0, 1
-    sd t0, -32(s0)
-    ld t0, -32(s0)
   endif_1:
     sd t0, -40(s0)
     ld a0, -40(s0)
@@ -71,8 +67,6 @@
     addi sp, sp, 8
     call fac
     mv t0, a0
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -110,8 +104,6 @@
     li t1, 3
     slt t2, t1, t0
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     mv t0, a0
     j endif_1
@@ -158,8 +150,6 @@
     ld t1, -40(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -48(s0)
-    ld t0, -48(s0)
   endif_1:
     sd t0, -56(s0)
     ld a0, -56(s0)
@@ -181,8 +171,6 @@
     addi sp, sp, 8
     call fib
     mv t0, a0
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -224,8 +212,6 @@
     mv t1, a0
     xor t2, t0, t1
     snez t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -240,8 +226,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     j endif_1
   else_0:
     addi sp, sp, -8
@@ -257,8 +241,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -16(s0)
-    ld t0, -16(s0)
   endif_1:
     sd t0, -24(s0)
     ld a0, -24(s0)
@@ -277,15 +259,11 @@
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_2
     li t0, 1
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     j endif_3
   else_2:
     li t0, 85
@@ -295,41 +273,27 @@
     addi sp, sp, 8
     call print_int
     mv t0, a0
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     sd t0, -24(s0)
     li t0, 3
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -32(s0)
-    ld t0, -32(s0)
   endif_3:
-    sd t0, -40(s0)
-    ld t0, -40(s0)
     beq t0, zero, else_4
     li t0, 1
     j endif_5
   else_4:
     li t0, 3
   endif_5:
-    sd t0, -48(s0)
-    ld t0, -48(s0)
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -56(s0)
-    ld t0, -56(s0)
     beq t0, zero, else_6
     li t0, 1
     j endif_7
   else_6:
     li t0, 3
   endif_7:
-    sd t0, -64(s0)
-    ld t0, -64(s0)
-    sd t0, -72(s0)
-    ld t0, -72(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -413,8 +377,6 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -500,8 +462,6 @@
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -517,8 +477,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     j endif_1
   else_0:
     mv t0, a0
@@ -599,8 +557,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -48(s0)
-    ld t0, -48(s0)
   endif_1:
     sd t0, -56(s0)
     ld a0, -56(s0)
@@ -628,8 +584,6 @@
     call apply1
     mv t0, a0
     addi sp, sp, 8
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     la a0, id
     li a1, 1
     call alloc_closure
@@ -638,8 +592,6 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -833,8 +785,6 @@
     mv t0, a0
     li t1, 5
     slt t0, t0, t1
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     addi sp, sp, -8
     sd a0, 0(sp)
@@ -850,8 +800,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     j endif_1
   else_0:
     mv t0, a0
@@ -950,8 +898,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -56(s0)
-    ld t0, -56(s0)
   endif_1:
     sd t0, -64(s0)
     ld a0, -64(s0)
@@ -979,8 +925,6 @@
     call apply1
     mv t0, a0
     addi sp, sp, 8
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     la a0, id
     li a1, 1
     call alloc_closure
@@ -989,16 +933,12 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
     addi sp, sp, 8
     call print_int
     mv t0, a0
-    sd t0, -24(s0)
-    ld t0, -24(s0)
     sd t0, -32(s0)
     li a0, 1
     addi sp, s0, 16
@@ -1027,8 +967,6 @@
     li t1, 3
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     mv t0, a0
     j endif_1
@@ -1067,8 +1005,6 @@
     addi sp, sp, 8
     ld a2, 0(sp)
     addi sp, sp, 8
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a2, 0(sp)
@@ -1085,8 +1021,6 @@
     addi sp, sp, 8
     ld a2, 0(sp)
     addi sp, sp, 8
-    sd t0, -24(s0)
-    ld t0, -24(s0)
     sd t0, -32(s0)
     addi sp, sp, -8
     sd a2, 0(sp)
@@ -1101,8 +1035,6 @@
     addi sp, sp, 8
     ld a2, 0(sp)
     addi sp, sp, 8
-    sd t0, -40(s0)
-    ld t0, -40(s0)
     sd t0, -48(s0)
     li a0, 1
     addi sp, s0, 16
@@ -1118,43 +1050,27 @@
     mv t1, a1
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     mv t1, a2
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     mv t1, a3
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -24(s0)
-    ld t0, -24(s0)
     mv t1, a4
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -32(s0)
-    ld t0, -32(s0)
     mv t1, a5
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -40(s0)
-    ld t0, -40(s0)
     mv t1, a6
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -48(s0)
-    ld t0, -48(s0)
     mv t1, a7
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -56(s0)
-    ld t0, -56(s0)
     ld t1, 16(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    sd t0, -64(s0)
-    ld t0, -64(s0)
     ld t1, 24(s0)
     add t0, t0, t1
     addi t0, t0, -1
@@ -1181,80 +1097,56 @@
     addi sp, sp, 8
     call wrap
     mv t0, a0
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     li t1, 3
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     li t1, 21
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -24(s0)
-    ld t0, -24(s0)
     li t1, 201
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -32(s0)
-    ld t0, -32(s0)
     li t1, 2001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -40(s0)
-    ld t0, -40(s0)
     li t1, 20001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -48(s0)
-    ld t0, -48(s0)
     li t1, 200001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -56(s0)
-    ld t0, -56(s0)
     li t1, 2000001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -64(s0)
-    ld t0, -64(s0)
     li t1, 20000001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -72(s0)
-    ld t0, -72(s0)
     li t1, 200000001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -80(s0)
-    ld t0, -80(s0)
     li t1, 2000000001
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -88(s0)
-    ld t0, -88(s0)
-    sd t0, -96(s0)
-    ld t0, -96(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
     ld a0, 0(sp)
@@ -1272,29 +1164,21 @@
     addi sp, sp, 8
     call wrap
     mv t0, a0
-    sd t0, -112(s0)
-    ld t0, -112(s0)
     li t1, 3
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -120(s0)
-    ld t0, -120(s0)
     li t1, 21
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -128(s0)
-    ld t0, -128(s0)
     li t1, 201
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -136(s0)
-    ld t0, -136(s0)
     sd t0, -144(s0)
     li a0, 1
     addi sp, s0, 16
@@ -1433,8 +1317,6 @@
     li t1, 1
     xor t2, t0, t1
     seqz t0, t2
-    sd t0, -8(s0)
-    ld t0, -8(s0)
     beq t0, zero, else_0
     mv t0, a1
     j endif_1
@@ -1505,8 +1387,6 @@
     addi sp, sp, 8
     ld a0, 0(sp)
     addi sp, sp, 8
-    sd t0, -40(s0)
-    ld t0, -40(s0)
   endif_1:
     sd t0, -48(s0)
     ld a0, -48(s0)
@@ -1537,31 +1417,21 @@
     call apply1
     mv t0, a0
     addi sp, sp, 8
-    sd t0, -16(s0)
-    ld t0, -16(s0)
     li t1, 1
     mv a0, t0
     mv a1, t1
     call apply1
     mv t0, a0
-    sd t0, -24(s0)
-    ld t0, -24(s0)
-    sd t0, -32(s0)
-    ld t0, -32(s0)
     sd t0, -40(s0)
     ld a0, -40(s0)
     li a1, 0
     call field
     mv t0, a0
-    sd t0, -48(s0)
-    ld t0, -48(s0)
     sd t0, -56(s0)
     ld a0, -40(s0)
     li a1, 1
     call field
     mv t0, a0
-    sd t0, -64(s0)
-    ld t0, -64(s0)
     sd t0, -72(s0)
     call print_gc_status
     mv t0, a0

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -305,13 +305,6 @@
   .global main
   .type main, @function
   id:
-    addi sp, sp, -56
-    sd ra, 48(sp)
-    sd s0, 40(sp)
-    addi s0, sp, 40
-    addi sp, s0, 16
-    ld ra, 8(s0)
-    ld s0, 0(s0)
     ret
   fresh_1:
     addi sp, sp, -72
@@ -472,13 +465,6 @@
   .global main
   .type main, @function
   id:
-    addi sp, sp, -56
-    sd ra, 48(sp)
-    sd s0, 40(sp)
-    addi s0, sp, 40
-    addi sp, s0, 16
-    ld ra, 8(s0)
-    ld s0, 0(s0)
     ret
   fresh_2:
     addi sp, sp, -72
@@ -1080,13 +1066,6 @@
   .global main
   .type main, @function
   f:
-    addi sp, sp, -56
-    sd ra, 48(sp)
-    sd s0, 40(sp)
-    addi s0, sp, 40
-    addi sp, s0, 16
-    ld ra, 8(s0)
-    ld s0, 0(s0)
     ret
   main:
     addi sp, sp, -144

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -29,10 +29,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     ld t0, -16(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call fac
     mv t0, a0
     addi sp, sp, 8
@@ -61,16 +58,10 @@
     li a0, 5120
     call rt_init
     li t0, 9
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call fac
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
@@ -117,10 +108,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     ld t0, -16(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call fib
     mv t0, a0
     addi sp, sp, 8
@@ -136,10 +124,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     ld t0, -32(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call fib
     mv t0, a0
     addi sp, sp, 8
@@ -165,16 +150,10 @@
     li a0, 5120
     call rt_init
     li t0, 13
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call fib
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
@@ -217,10 +196,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     li t0, 1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -232,10 +208,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     li t0, 3
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -267,10 +240,7 @@
     j endif_3
   else_2:
     li t0, 85
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -24(s0)
@@ -294,10 +264,7 @@
   else_6:
     li t0, 3
   endif_7:
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call large
     mv t0, a0
     sd t0, -80(s0)
@@ -377,10 +344,7 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
@@ -592,10 +556,7 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -24(s0)
@@ -933,10 +894,7 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -32(s0)
@@ -992,10 +950,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -1011,10 +966,7 @@
     addi sp, sp, -8
     sd a1, 0(sp)
     mv t0, a1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     ld a1, 0(sp)
@@ -1026,10 +978,7 @@
     sd a2, 0(sp)
     addi sp, sp, -8
     mv t0, a2
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     addi sp, sp, 8
@@ -1091,10 +1040,7 @@
     li a1, 10
     call alloc_closure
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call wrap
     mv t0, a0
     li t1, 3
@@ -1147,10 +1093,7 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -104(s0)
@@ -1158,10 +1101,7 @@
     li a1, 3
     call alloc_closure
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call wrap
     mv t0, a0
     li t1, 3
@@ -1282,10 +1222,7 @@
     ld t1, -64(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -80(s0)
@@ -1390,10 +1327,7 @@
     sd t1, 8(t2)
     ld t0, 0(sp)
     addi sp, sp, 8
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call swap
     mv t0, a0
     sd t0, -40(s0)
@@ -1408,10 +1342,7 @@
     mv t0, a0
     sd t0, -72(s0)
     ld t0, -56(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -80(s0)
@@ -1455,18 +1386,12 @@
     li a0, 5120
     call rt_init
     li t0, 21
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call f
     mv t0, a0
     sd t0, -8(s0)
     li t0, 41
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call f
     mv t0, a0
     sd t0, -16(s0)
@@ -1501,10 +1426,7 @@
     ld t1, -72(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -88(s0)
@@ -1573,10 +1495,7 @@
     sd a0, 0(sp)
     addi sp, sp, -8
     ld t0, -48(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call sum_list
     mv t0, a0
     addi sp, sp, 8
@@ -1651,16 +1570,10 @@
     sd t1, 8(t2)
     ld t0, 0(sp)
     addi sp, sp, 8
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call sum_list
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -48(s0)
@@ -1789,10 +1702,7 @@
     li a1, 9
     call field
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -192(s0)
@@ -1854,10 +1764,7 @@
     ld t1, -56(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -72(s0)
@@ -1949,10 +1856,7 @@
     ld t1, -88(s0)
     add t0, t0, t1
     addi t0, t0, -1
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -112(s0)
@@ -2041,16 +1945,10 @@
     sd t1, 8(t2)
     ld t0, 0(sp)
     addi sp, sp, 8
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call sum_pair
     mv t0, a0
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -32(s0)
@@ -2209,10 +2107,7 @@
     mv t0, a0
     sd t0, -80(s0)
     ld t0, -56(s0)
-    addi sp, sp, -8
-    sd t0, 0(sp)
     mv a0, t0
-    addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -88(s0)

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -18,19 +18,16 @@
     li t0, 3
     j endif_1
   else_0:
-    mv t0, a0
-    addi t0, t0, -2
+    addi t0, a0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    ld t0, -16(s0)
-    mv a0, t0
+    ld a0, -16(s0)
     call fac
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -24(s0)
     mv t0, a0
     ld t1, -24(s0)
@@ -56,8 +53,7 @@
     li a0, 9
     call fac
     call print_int
-    mv t0, a0
-    sd t0, -16(s0)
+    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -89,33 +85,27 @@
     mv t0, a0
     j endif_1
   else_0:
-    mv t0, a0
-    addi t0, t0, -2
+    addi t0, a0, -2
     sd t0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    ld t0, -16(s0)
-    mv a0, t0
+    ld a0, -16(s0)
     call fib
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -24(s0)
-    mv t0, a0
-    addi t0, t0, -4
+    addi t0, a0, -4
     sd t0, -32(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    ld t0, -32(s0)
-    mv a0, t0
+    ld a0, -32(s0)
     call fib
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -40(s0)
     ld t0, -24(s0)
     ld t1, -40(s0)
@@ -138,8 +128,7 @@
     li a0, 13
     call fib
     call print_int
-    mv t0, a0
-    sd t0, -16(s0)
+    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -178,9 +167,8 @@
     li a0, 1
     call print_int
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     j endif_1
   else_0:
     addi sp, sp, -8
@@ -189,9 +177,8 @@
     li a0, 3
     call print_int
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
   endif_1:
     sd t0, -24(s0)
     mv a0, t0
@@ -217,8 +204,7 @@
   else_2:
     li a0, 85
     call print_int
-    mv t0, a0
-    sd t0, -24(s0)
+    sd a0, -24(s0)
     li t0, 3
     li t1, 3
     xor t2, t0, t1
@@ -239,8 +225,7 @@
   endif_7:
     mv a0, t0
     call large
-    mv t0, a0
-    sd t0, -80(s0)
+    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -289,8 +274,7 @@
     la a0, simplesum
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
     addi sp, sp, 8
@@ -311,8 +295,7 @@
     li a1, 11
     call apply1
     call print_int
-    mv t0, a0
-    sd t0, -16(s0)
+    sd a0, -16(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -355,9 +338,8 @@
     add t0, t0, t0
     addi t0, t0, 1
     sd t0, -8(s0)
-    addi sp, sp, -8
-    sd a2, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a2, 8(sp)
     sd a0, 0(sp)
     addi sp, sp, -8
     sd a1, 0(sp)
@@ -368,13 +350,10 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    ld a2, 24(sp)
+    addi sp, sp, 32
     sd t0, -16(s0)
     mv a0, t0
     addi sp, s0, 16
@@ -389,9 +368,8 @@
     mv t0, a0
     li t1, 3
     bne t0, t1, else_0
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     mv t0, a1
     li t1, 3
@@ -400,17 +378,14 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     j endif_1
   else_0:
-    mv t0, a0
-    addi t0, t0, -2
+    addi t0, a0, -2
     sd t0, -16(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     ld t1, -16(s0)
@@ -418,52 +393,40 @@
     la a0, fac_cps
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    addi sp, sp, 24
     sd t0, -24(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
-    mv t1, a0
-    sd t1, 0(sp)
+    sd a0, 0(sp)
     la a0, fresh_1
     li a1, 3
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    addi sp, sp, 24
     sd t0, -32(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
-    ld t0, -32(s0)
-    mv a0, t0
+    ld a0, -32(s0)
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -40(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     ld t0, -24(s0)
     ld t1, -40(s0)
@@ -472,9 +435,8 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
   endif_1:
     sd t0, -56(s0)
     mv a0, t0
@@ -495,8 +457,7 @@
     la a0, fac_cps
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
     addi sp, sp, 8
@@ -508,8 +469,7 @@
     mv a1, t1
     call apply1
     call print_int
-    mv t0, a0
-    sd t0, -24(s0)
+    sd a0, -24(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -548,9 +508,8 @@
     add t0, t0, t1
     addi t0, t0, -1
     sd t0, -8(s0)
-    addi sp, sp, -8
-    sd a2, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a2, 8(sp)
     sd a0, 0(sp)
     addi sp, sp, -8
     sd a1, 0(sp)
@@ -561,13 +520,10 @@
     mv a1, t1
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    ld a2, 24(sp)
+    addi sp, sp, 32
     sd t0, -16(s0)
     mv a0, t0
     addi sp, s0, 16
@@ -579,16 +535,13 @@
     sd ra, 88(sp)
     sd s0, 80(sp)
     addi s0, sp, 80
-    mv t0, a0
-    addi t0, t0, -4
+    addi t0, a0, -4
     sd t0, -8(s0)
-    addi sp, sp, -8
-    sd a3, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a3, 8(sp)
     sd a0, 0(sp)
-    addi sp, sp, -8
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a1, 8(sp)
     sd a2, 0(sp)
     mv t0, a2
     ld t1, -8(s0)
@@ -597,70 +550,51 @@
     call apply1
     mv t0, a0
     ld a2, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a3, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    ld a3, 24(sp)
+    addi sp, sp, 32
     sd t0, -16(s0)
-    addi sp, sp, -8
-    sd a3, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a3, 8(sp)
     sd a0, 0(sp)
-    addi sp, sp, -8
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a1, 8(sp)
     sd a2, 0(sp)
     addi sp, sp, -8
-    mv t1, a3
-    sd t1, 0(sp)
+    sd a3, 0(sp)
     la a0, fresh_2
     li a1, 3
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a3, 0(sp)
-    addi sp, sp, 8
+    ld a2, 8(sp)
+    ld a1, 16(sp)
+    ld a0, 24(sp)
+    ld a3, 32(sp)
+    addi sp, sp, 40
     sd t0, -24(s0)
-    addi sp, sp, -8
-    sd a3, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a3, 8(sp)
     sd a0, 0(sp)
-    addi sp, sp, -8
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a1, 8(sp)
     sd a2, 0(sp)
-    ld t0, -24(s0)
-    mv a0, t0
+    ld a0, -24(s0)
     call apply1
     mv t0, a0
     ld a2, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a3, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    ld a3, 24(sp)
+    addi sp, sp, 32
     sd t0, -32(s0)
-    addi sp, sp, -8
-    sd a3, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a3, 8(sp)
     sd a0, 0(sp)
-    addi sp, sp, -8
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a1, 8(sp)
     sd a2, 0(sp)
     ld t0, -16(s0)
     ld t1, -32(s0)
@@ -669,13 +603,10 @@
     call apply1
     mv t0, a0
     ld a2, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a3, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    ld a3, 24(sp)
+    addi sp, sp, 32
     sd t0, -40(s0)
     mv a0, t0
     addi sp, s0, 16
@@ -690,9 +621,8 @@
     mv t0, a0
     li t1, 5
     ble t1, t0, else_0
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     mv t0, a1
     mv t1, a0
@@ -701,17 +631,14 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     j endif_1
   else_0:
-    mv t0, a0
-    addi t0, t0, -2
+    addi t0, a0, -2
     sd t0, -16(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     ld t1, -16(s0)
@@ -719,52 +646,40 @@
     la a0, fib
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    addi sp, sp, 24
     sd t0, -24(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
-    mv t1, a0
-    sd t1, 0(sp)
+    sd a0, 0(sp)
     la a0, fresh_1
     li a1, 4
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    addi sp, sp, 24
     sd t0, -32(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
-    ld t0, -32(s0)
-    mv a0, t0
+    ld a0, -32(s0)
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -40(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     ld t0, -40(s0)
     la a0, fib
@@ -776,13 +691,11 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -48(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     ld t0, -24(s0)
     ld t1, -48(s0)
@@ -791,9 +704,8 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
   endif_1:
     sd t0, -64(s0)
     mv a0, t0
@@ -814,8 +726,7 @@
     la a0, fib
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
     addi sp, sp, 8
@@ -827,8 +738,7 @@
     mv a1, t1
     call apply1
     call print_int
-    mv t0, a0
-    sd t0, -32(s0)
+    sd a0, -32(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -871,35 +781,29 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    addi sp, sp, -8
-    sd a2, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a2, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
     call print_int
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    ld a1, 16(sp)
+    ld a2, 24(sp)
+    addi sp, sp, 32
     sd t0, -16(s0)
-    addi sp, sp, -8
-    sd a2, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a2, 8(sp)
     sd a1, 0(sp)
     mv t0, a1
     mv a0, t0
     call print_int
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
+    ld a2, 8(sp)
+    addi sp, sp, 16
     sd t0, -32(s0)
     addi sp, sp, -8
     sd a2, 0(sp)
@@ -908,9 +812,8 @@
     mv a0, t0
     call print_int
     mv t0, a0
-    addi sp, sp, 8
-    ld a2, 0(sp)
-    addi sp, sp, 8
+    ld a2, 8(sp)
+    addi sp, sp, 16
     sd t0, -48(s0)
     li a0, 1
     addi sp, s0, 16
@@ -988,8 +891,7 @@
     li a1, 2000000001
     call apply1
     call print_int
-    mv t0, a0
-    sd t0, -104(s0)
+    sd a0, -104(s0)
     la a0, test3
     li a1, 3
     call alloc_closure
@@ -1000,8 +902,7 @@
     call apply1
     li a1, 201
     call apply1
-    mv t0, a0
-    sd t0, -144(s0)
+    sd a0, -144(s0)
     li a0, 1
     addi sp, s0, 16
     ld ra, 8(s0)
@@ -1034,9 +935,8 @@
     sd ra, 56(sp)
     sd s0, 48(sp)
     addi s0, sp, 48
-    addi sp, sp, -16
-    sd a1, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a1, 8(sp)
     sd a0, 0(sp)
     addi sp, sp, -8
     li a0, 2
@@ -1044,9 +944,8 @@
     addi sp, sp, 8
     sd a0, 16(sp)
     ld a0, 0(sp)
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    addi sp, sp, 16
     mv t1, a0
     ld t2, 0(sp)
     addi t2, t2, 16
@@ -1076,8 +975,7 @@
     la a0, make_pair
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
     addi sp, sp, 8
@@ -1085,25 +983,21 @@
     mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    sd t0, -32(s0)
+    sd a0, -32(s0)
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -48(s0)
+    sd a0, -48(s0)
     ld a0, -32(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -64(s0)
+    sd a0, -64(s0)
     ld t0, -48(s0)
     ld t1, -64(s0)
     add t0, t0, t1
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    mv t0, a0
-    sd t0, -80(s0)
+    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1133,8 +1027,7 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    mv t0, a0
-    sd t0, -8(s0)
+    sd a0, -8(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -1204,22 +1097,17 @@
     addi sp, sp, 8
     mv a0, t0
     call swap
-    mv t0, a0
-    sd t0, -40(s0)
+    sd a0, -40(s0)
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     ld a0, -40(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -72(s0)
-    ld t0, -56(s0)
-    mv a0, t0
+    sd a0, -72(s0)
+    ld a0, -56(s0)
     call print_int
-    mv t0, a0
-    sd t0, -80(s0)
+    sd a0, -80(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1260,12 +1148,10 @@
     call rt_init
     li a0, 21
     call f
-    mv t0, a0
-    sd t0, -8(s0)
+    sd a0, -8(s0)
     li a0, 41
     call f
-    mv t0, a0
-    sd t0, -16(s0)
+    sd a0, -16(s0)
     addi sp, sp, -16
     li a0, 2
     call create_tuple
@@ -1285,21 +1171,18 @@
     mv a0, t0
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     ld a0, -40(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -72(s0)
+    sd a0, -72(s0)
     ld t0, -56(s0)
     ld t1, -72(s0)
     add t0, t0, t1
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    mv t0, a0
-    sd t0, -88(s0)
+    sd a0, -88(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1334,8 +1217,7 @@
     li t0, 1
     j endif_1
   else_0:
-    mv t0, a0
-    sd t0, -16(s0)
+    sd a0, -16(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -1361,13 +1243,11 @@
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
-    ld t0, -48(s0)
-    mv a0, t0
+    ld a0, -48(s0)
     call sum_list
     mv t0, a0
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     sd t0, -56(s0)
     ld t0, -32(s0)
     ld t1, -56(s0)
@@ -1437,8 +1317,7 @@
     mv a0, t0
     call sum_list
     call print_int
-    mv t0, a0
-    sd t0, -48(s0)
+    sd a0, -48(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1516,54 +1395,44 @@
     mv a0, t0
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -40(s0)
+    sd a0, -40(s0)
     ld a0, -24(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     ld a0, -24(s0)
     li a1, 2
     call field
-    mv t0, a0
-    sd t0, -72(s0)
+    sd a0, -72(s0)
     ld a0, -24(s0)
     li a1, 3
     call field
-    mv t0, a0
-    sd t0, -88(s0)
+    sd a0, -88(s0)
     ld a0, -24(s0)
     li a1, 4
     call field
-    mv t0, a0
-    sd t0, -104(s0)
+    sd a0, -104(s0)
     ld a0, -24(s0)
     li a1, 5
     call field
-    mv t0, a0
-    sd t0, -120(s0)
+    sd a0, -120(s0)
     ld a0, -24(s0)
     li a1, 6
     call field
-    mv t0, a0
-    sd t0, -136(s0)
+    sd a0, -136(s0)
     ld a0, -24(s0)
     li a1, 7
     call field
-    mv t0, a0
-    sd t0, -152(s0)
+    sd a0, -152(s0)
     ld a0, -24(s0)
     li a1, 8
     call field
-    mv t0, a0
-    sd t0, -168(s0)
+    sd a0, -168(s0)
     ld a0, -24(s0)
     li a1, 9
     call field
     call print_int
-    mv t0, a0
-    sd t0, -192(s0)
+    sd a0, -192(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1609,21 +1478,18 @@
     mv a0, t0
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -40(s0)
+    sd a0, -40(s0)
     ld a0, -24(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     ld t0, -40(s0)
     ld t1, -56(s0)
     add t0, t0, t1
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    mv t0, a0
-    sd t0, -72(s0)
+    sd a0, -72(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1685,22 +1551,18 @@
     mv a0, t0
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -48(s0)
+    sd a0, -48(s0)
     ld a0, -32(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -72(s0)
+    sd a0, -72(s0)
     ld a0, -56(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -88(s0)
+    sd a0, -88(s0)
     ld t0, -48(s0)
     ld t1, -72(s0)
     add t0, t0, t1
@@ -1710,8 +1572,7 @@
     addi t0, t0, -1
     mv a0, t0
     call print_int
-    mv t0, a0
-    sd t0, -112(s0)
+    sd a0, -112(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1739,8 +1600,7 @@
     sd ra, 96(sp)
     sd s0, 88(sp)
     addi s0, sp, 88
-    mv t0, a0
-    sd t0, -8(s0)
+    sd a0, -8(s0)
     addi sp, sp, -8
     sd a0, 0(sp)
     addi sp, sp, -8
@@ -1798,8 +1658,7 @@
     mv a0, t0
     call sum_pair
     call print_int
-    mv t0, a0
-    sd t0, -32(s0)
+    sd a0, -32(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1836,12 +1695,10 @@
     mv t0, a1
     j endif_1
   else_0:
-    mv t0, a0
-    addi t0, t0, -2
+    addi t0, a0, -2
     sd t0, -16(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     ld t1, -16(s0)
@@ -1849,19 +1706,15 @@
     la a0, make_list
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
-    addi sp, sp, 8
-    ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a1, 8(sp)
+    ld a0, 16(sp)
+    addi sp, sp, 24
     sd t0, -24(s0)
-    addi sp, sp, -16
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -24
+    sd a0, 8(sp)
     sd a1, 0(sp)
     addi sp, sp, -8
     li a0, 2
@@ -1869,9 +1722,8 @@
     addi sp, sp, 8
     sd a0, 16(sp)
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
     mv t1, a0
     ld t2, 0(sp)
     addi t2, t2, 16
@@ -1883,9 +1735,8 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -32(s0)
-    addi sp, sp, -8
-    sd a0, 0(sp)
-    addi sp, sp, -8
+    addi sp, sp, -16
+    sd a0, 8(sp)
     sd a1, 0(sp)
     ld t0, -24(s0)
     ld t1, -32(s0)
@@ -1894,9 +1745,8 @@
     call apply1
     mv t0, a0
     ld a1, 0(sp)
-    addi sp, sp, 8
-    ld a0, 0(sp)
-    addi sp, sp, 8
+    ld a0, 8(sp)
+    addi sp, sp, 16
   endif_1:
     sd t0, -48(s0)
     mv a0, t0
@@ -1912,16 +1762,14 @@
     li a0, 5120
     call rt_init
     call print_gc_status
-    mv t0, a0
-    sd t0, -8(s0)
+    sd a0, -8(s0)
     addi sp, sp, -8
     li t1, 20001
     sd t1, 0(sp)
     la a0, make_list
     li a1, 2
     call alloc_closure
-    ld t1, 0(sp)
-    mv a1, t1
+    ld a1, 0(sp)
     call apply1
     mv t0, a0
     addi sp, sp, 8
@@ -1929,25 +1777,19 @@
     mv a0, t0
     mv a1, t1
     call apply1
-    mv t0, a0
-    sd t0, -40(s0)
+    sd a0, -40(s0)
     li a1, 0
     call field
-    mv t0, a0
-    sd t0, -56(s0)
+    sd a0, -56(s0)
     ld a0, -40(s0)
     li a1, 1
     call field
-    mv t0, a0
-    sd t0, -72(s0)
+    sd a0, -72(s0)
     call print_gc_status
-    mv t0, a0
-    sd t0, -80(s0)
-    ld t0, -56(s0)
-    mv a0, t0
+    sd a0, -80(s0)
+    ld a0, -56(s0)
     call print_int
-    mv t0, a0
-    sd t0, -88(s0)
+    sd a0, -88(s0)
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)

--- a/XML/many_tests/codegen.t
+++ b/XML/many_tests/codegen.t
@@ -31,7 +31,7 @@
     ld t0, -16(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call fac
     mv t0, a0
@@ -48,7 +48,7 @@
     addi t0, t0, 1
   endif_1:
     sd t0, -40(s0)
-    ld a0, -40(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -63,18 +63,18 @@
     li t0, 9
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call fac
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -119,7 +119,7 @@
     ld t0, -16(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call fib
     mv t0, a0
@@ -138,7 +138,7 @@
     ld t0, -32(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call fib
     mv t0, a0
@@ -152,7 +152,7 @@
     addi t0, t0, -1
   endif_1:
     sd t0, -56(s0)
-    ld a0, -56(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -167,18 +167,18 @@
     li t0, 13
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call fib
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -219,7 +219,7 @@
     li t0, 1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -234,7 +234,7 @@
     li t0, 3
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -243,7 +243,7 @@
     addi sp, sp, 8
   endif_1:
     sd t0, -24(s0)
-    ld a0, -24(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -269,7 +269,7 @@
     li t0, 85
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -296,12 +296,12 @@
   endif_7:
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call large
     mv t0, a0
     sd t0, -80(s0)
-    ld a0, -80(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -334,7 +334,7 @@
     add t0, t0, t1
     addi t0, t0, -1
     sd t0, -8(s0)
-    ld a0, -8(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -358,7 +358,7 @@
     mv t0, a0
     addi sp, sp, 8
     sd t0, -8(s0)
-    ld a0, -8(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -379,12 +379,12 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -448,7 +448,7 @@
     ld a2, 0(sp)
     addi sp, sp, 8
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -559,7 +559,7 @@
     addi sp, sp, 8
   endif_1:
     sd t0, -56(s0)
-    ld a0, -56(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -594,7 +594,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -658,7 +658,7 @@
     ld a2, 0(sp)
     addi sp, sp, 8
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -772,7 +772,7 @@
     ld a3, 0(sp)
     addi sp, sp, 8
     sd t0, -40(s0)
-    ld a0, -40(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -900,7 +900,7 @@
     addi sp, sp, 8
   endif_1:
     sd t0, -64(s0)
-    ld a0, -64(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -935,7 +935,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -974,7 +974,7 @@
     mv t0, a0
   endif_1:
     sd t0, -16(s0)
-    ld a0, -16(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -994,7 +994,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -1013,7 +1013,7 @@
     mv t0, a1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -1028,7 +1028,7 @@
     mv t0, a2
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -1075,7 +1075,7 @@
     add t0, t0, t1
     addi t0, t0, -1
     sd t0, -72(s0)
-    ld a0, -72(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1093,7 +1093,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call wrap
     mv t0, a0
@@ -1149,7 +1149,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
@@ -1160,7 +1160,7 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call wrap
     mv t0, a0
@@ -1237,7 +1237,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -8(s0)
-    ld a0, -8(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1268,7 +1268,7 @@
     call apply1
     mv t0, a0
     sd t0, -32(s0)
-    ld a0, -32(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1284,12 +1284,12 @@
     addi t0, t0, -1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -80(s0)
-    ld a0, -80(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1362,7 +1362,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -48(s0)
-    ld a0, -48(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1392,12 +1392,12 @@
     addi sp, sp, 8
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call swap
     mv t0, a0
     sd t0, -40(s0)
-    ld a0, -40(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1410,12 +1410,12 @@
     ld t0, -56(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -80(s0)
-    ld a0, -80(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1457,7 +1457,7 @@
     li t0, 21
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call f
     mv t0, a0
@@ -1465,7 +1465,7 @@
     li t0, 41
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call f
     mv t0, a0
@@ -1487,7 +1487,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -40(s0)
-    ld a0, -40(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1503,12 +1503,12 @@
     addi t0, t0, -1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -88(s0)
-    ld a0, -88(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1575,7 +1575,7 @@
     ld t0, -48(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call sum_list
     mv t0, a0
@@ -1589,7 +1589,7 @@
     addi t0, t0, -1
   endif_1:
     sd t0, -72(s0)
-    ld a0, -72(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1653,18 +1653,18 @@
     addi sp, sp, 8
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call sum_list
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -48(s0)
-    ld a0, -48(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1740,7 +1740,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -24(s0)
-    ld a0, -24(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1791,12 +1791,12 @@
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -192(s0)
-    ld a0, -192(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1840,7 +1840,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -24(s0)
-    ld a0, -24(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1856,12 +1856,12 @@
     addi t0, t0, -1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -72(s0)
-    ld a0, -72(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -1922,7 +1922,7 @@
     ld t0, 0(sp)
     addi sp, sp, 8
     sd t0, -32(s0)
-    ld a0, -32(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1932,7 +1932,7 @@
     call field
     mv t0, a0
     sd t0, -56(s0)
-    ld a0, -56(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -1951,12 +1951,12 @@
     addi t0, t0, -1
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -112(s0)
-    ld a0, -112(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -2013,7 +2013,7 @@
     add t0, t0, t1
     addi t0, t0, -1
     sd t0, -48(s0)
-    ld a0, -48(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -2043,18 +2043,18 @@
     addi sp, sp, 8
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call sum_pair
     mv t0, a0
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -32(s0)
-    ld a0, -32(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -2161,7 +2161,7 @@
     addi sp, sp, 8
   endif_1:
     sd t0, -48(s0)
-    ld a0, -48(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)
@@ -2195,7 +2195,7 @@
     call apply1
     mv t0, a0
     sd t0, -40(s0)
-    ld a0, -40(s0)
+    mv a0, t0
     li a1, 0
     call field
     mv t0, a0
@@ -2211,12 +2211,12 @@
     ld t0, -56(s0)
     addi sp, sp, -8
     sd t0, 0(sp)
-    ld a0, 0(sp)
+    mv a0, t0
     addi sp, sp, 8
     call print_int
     mv t0, a0
     sd t0, -88(s0)
-    ld a0, -88(s0)
+    mv a0, t0
     addi sp, s0, 16
     ld ra, 8(s0)
     ld s0, 0(s0)

--- a/XML/many_tests/codegen_operators.t
+++ b/XML/many_tests/codegen_operators.t
@@ -1,0 +1,112 @@
+  $ clang-18 --target=riscv64-linux-gnu --sysroot=/usr/riscv64-unknown-linux-gnu -c ./../bin/runtime.c -o runtime.o
+
+====================== Llvm ======================
+
+====================== Custom operators ======================
+
+  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom1.ll <<EOF
+  > let (@) f x = f x in
+  > print_int ((@) (fun x -> x) 5)
+  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
+  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
+  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
+  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
+  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
+  [2]
+
+  $ cat oper_custom1.ll
+  cat: oper_custom1.ll: No such file or directory
+  [1]
+
+  $ llc-18 oper_custom1.ll -o temp.s
+  llc-18: error: llc-18: oper_custom1.ll: error: Could not open input file: No such file or directory
+  [1]
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  clang-18: error: no such file or directory: 'temp.s'
+  [1]
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  [1]
+
+
+
+  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom2.ll <<EOF
+  > let (@) f x = f x in
+  > print_int ((fun x -> x) @ 5)
+  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
+  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
+  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
+  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
+  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
+  [2]
+
+  $ cat oper_custom2.ll
+  cat: oper_custom2.ll: No such file or directory
+  [1]
+
+  $ llc-18 oper_custom2.ll -o temp.s
+  llc-18: error: llc-18: oper_custom2.ll: error: Could not open input file: No such file or directory
+  [1]
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  clang-18: error: no such file or directory: 'temp.s'
+  [1]
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  [1]
+
+
+
+  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom3.ll <<EOF
+  > let (@) f x = f x;;
+  > 
+  > print_int ((@) (fun x -> x) 5)
+  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
+  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
+  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
+  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
+  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
+  [2]
+
+  $ cat oper_custom3.ll
+  cat: oper_custom3.ll: No such file or directory
+  [1]
+
+  $ llc-18 oper_custom3.ll -o temp.s
+  llc-18: error: llc-18: oper_custom3.ll: error: Could not open input file: No such file or directory
+  [1]
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  clang-18: error: no such file or directory: 'temp.s'
+  [1]
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  [1]
+
+
+  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom4.ll <<EOF
+  > let (@) f x = f x;;
+  > 
+  > print_int ((fun x -> x) @ 5)
+  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
+  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
+  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
+  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
+  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
+  [2]
+
+  $ cat oper_custom4.ll
+  cat: oper_custom4.ll: No such file or directory
+  [1]
+
+  $ llc-18 oper_custom4.ll -o temp.s
+  llc-18: error: llc-18: oper_custom4.ll: error: Could not open input file: No such file or directory
+  [1]
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  clang-18: error: no such file or directory: 'temp.s'
+  [1]
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  [1]

--- a/XML/many_tests/codegen_operators.t
+++ b/XML/many_tests/codegen_operators.t
@@ -1,112 +1,189 @@
+llvm and riscv tests to check if operators are compiled correctly
+\
   $ clang-18 --target=riscv64-linux-gnu --sysroot=/usr/riscv64-unknown-linux-gnu -c ./../bin/runtime.c -o runtime.o
 
 ====================== Llvm ======================
 
-====================== Custom operators ======================
+====================== Custom operators used as functions ======================
 
   $ dune exec ../bin/XML_llvm.exe -- -o oper_custom1.ll <<EOF
   > let (@) f x = f x in
   > print_int ((@) (fun x -> x) 5)
-  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
-  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
-  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
-  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
-  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
-  [2]
-
-  $ cat oper_custom1.ll
-  cat: oper_custom1.ll: No such file or directory
-  [1]
 
   $ llc-18 oper_custom1.ll -o temp.s
-  llc-18: error: llc-18: oper_custom1.ll: error: Could not open input file: No such file or directory
-  [1]
   $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
-  clang-18: error: no such file or directory: 'temp.s'
-  [1]
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
-  [1]
-
-
-
-  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom2.ll <<EOF
-  > let (@) f x = f x in
-  > print_int ((fun x -> x) @ 5)
-  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
-  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
-  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
-  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
-  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
-  [2]
-
-  $ cat oper_custom2.ll
-  cat: oper_custom2.ll: No such file or directory
-  [1]
-
-  $ llc-18 oper_custom2.ll -o temp.s
-  llc-18: error: llc-18: oper_custom2.ll: error: Could not open input file: No such file or directory
-  [1]
-  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
-  clang-18: error: no such file or directory: 'temp.s'
-  [1]
-  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
-  [1]
-
+  5
 
 
   $ dune exec ../bin/XML_llvm.exe -- -o oper_custom3.ll <<EOF
   > let (@) f x = f x;;
   > 
   > print_int ((@) (fun x -> x) 5)
-  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
-  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
-  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
-  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
-  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
-  [2]
-
-  $ cat oper_custom3.ll
-  cat: oper_custom3.ll: No such file or directory
-  [1]
 
   $ llc-18 oper_custom3.ll -o temp.s
-  llc-18: error: llc-18: oper_custom3.ll: error: Could not open input file: No such file or directory
-  [1]
   $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
-  clang-18: error: no such file or directory: 'temp.s'
-  [1]
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
-  [1]
+  5
+
+====================== Custom operators used infixly ======================
+
+
+  $ dune exec ../bin/XML_llvm.exe -- -o oper_custom2.ll <<EOF
+  > let (@) f x = f x in
+  > print_int ((fun x -> x) @ 5)
+
+  $ llc-18 oper_custom2.ll -o temp.s
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  5
 
 
   $ dune exec ../bin/XML_llvm.exe -- -o oper_custom4.ll <<EOF
   > let (@) f x = f x;;
   > 
   > print_int ((fun x -> x) @ 5)
-  Fatal error: exception Invalid_argument("Unsupported binary operator: @")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from Backend__Codegen_llvm.gen_anf_expr in file "lib/backend/codegen_llvm.ml", line 291, characters 19-54
-  Called from Backend__Codegen_llvm.gen_astructure_item in file "lib/backend/codegen_llvm.ml", line 344, characters 21-47
-  Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
-  Called from Backend__Codegen_llvm.gen_program_ir in file "lib/backend/codegen_llvm.ml", line 389, characters 4-119
-  Called from Dune__exe__XML_llvm.to_llvm_ir in file "bin/XML_llvm.ml", line 39, characters 2-55
-  [2]
-
-  $ cat oper_custom4.ll
-  cat: oper_custom4.ll: No such file or directory
-  [1]
 
   $ llc-18 oper_custom4.ll -o temp.s
-  llc-18: error: llc-18: oper_custom4.ll: error: Could not open input file: No such file or directory
-  [1]
   $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
-  clang-18: error: no such file or directory: 'temp.s'
-  [1]
   $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
-  [1]
+  5
+
+====================== Renaming ======================
+
+  $ dune exec ../bin/XML_llvm.exe -- -o renaming1.ll <<EOF
+  > let (+) x y = x - y
+  > let main =
+  >  print_int (10 + 5)
+
+  $ llc-18 renaming1.ll -o temp.s
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  5
+
+
+  $ dune exec ../bin/XML_llvm.exe -- -o renaming2.ll <<EOF
+  > let g x y = x + y
+  > let (+) x y = x - y
+  > let main =
+  >  let _ = print_int (g 10 5) in
+  >  print_int (10 + 5)
+
+  $ llc-18 renaming2.ll -o temp.s
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  15
+  5
+
+====================== Associativity ======================
+
+  $ dune exec ../bin/XML_llvm.exe -- -o associativity.ll <<EOF
+  > let (+>) x y = x + y;;
+  > let (***) x y = x * y;;
+  > let (=&) x y = x - y;;
+  > let main =
+  >   print_int (2 +> 2 *** 2 =& 3)
+
+  $ llc-18 associativity.ll -o temp.s
+  $ clang-18  --target=riscv64-linux-gnu -static temp.s runtime.o -o temp.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64 ./temp.exe
+  3
+
+
+====================== RISC-V ======================
+
+====================== Custom operators used as functions ======================
+
+  $ dune exec ../bin/XML.exe -- -o oper_custom1.s <<EOF
+  > let (@) f x = f x in
+  > print_int ((@) (fun x -> x) 5)
+
+  $ riscv64-linux-gnu-as -march=rv64gc oper_custom1.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  5
+
+
+
+  $ dune exec ../bin/XML.exe -- -o oper_custom3.s <<EOF
+  > let (@) f x = f x;;
+  > 
+  > print_int ((@) (fun x -> x) 5)
+
+  $ riscv64-linux-gnu-as -march=rv64gc oper_custom3.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  5
+
+
+====================== Custom operators used infixly ======================
+
+  $ dune exec ../bin/XML.exe -- -o oper_custom2.s <<EOF
+  > let (@) f x = f x in
+  > print_int ((fun x -> x) @ 5)
+
+
+  $ riscv64-linux-gnu-as -march=rv64gc oper_custom2.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  5
+
+
+
+  $ dune exec ../bin/XML.exe -- -o oper_custom4.s <<EOF
+  > let (@) f x = f x;;
+  > 
+  > print_int ((fun x -> x) @ 5)
+
+  $ riscv64-linux-gnu-as -march=rv64gc oper_custom4.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  5
+
+====================== Renaming ======================
+
+  $ dune exec ../bin/XML.exe -- -o renaming1.s <<EOF
+  > let (+) x y = x - y
+  > let main =
+  >  print_int (10 + 5)
+
+  $ riscv64-linux-gnu-as -march=rv64gc renaming1.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  5
+
+
+
+  $ dune exec ../bin/XML.exe -- -o renaming2.s <<EOF
+  > let g x y = x + y
+  > let (+) x y = x - y
+  > let main =
+  >  let _ = print_int (g 10 5) in
+  >  print_int (10 + 5)
+
+  $ riscv64-linux-gnu-as -march=rv64gc renaming2.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  15
+  5
+
+====================== Associativity ======================
+
+  $ dune exec ../bin/XML.exe -- -o associativity.s <<EOF
+  > let (+>) x y = x + y;;
+  > let (***) x y = x * y;;
+  > let (=&) x y = x - y;;
+  > let main =
+  >   print_int (2 +> 2 *** 2 =& 3)
+
+  $ riscv64-linux-gnu-as -march=rv64gc associativity.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  3

--- a/XML/many_tests/dune
+++ b/XML/many_tests/dune
@@ -18,6 +18,7 @@
  (applies_to
   codegen
   codegen_llvm
+  codegen_operators
   anf
   cc
   ll

--- a/XML/many_tests/dune
+++ b/XML/many_tests/dune
@@ -56,3 +56,7 @@
   manytests/typed/013foldfoldr.ml
   manytests/typed/015tuples.ml
   manytests/typed/016lists.ml))
+
+(cram
+ (applies_to optimization_diff)
+ (deps codegen.t unoptimized_codegen.t))

--- a/XML/many_tests/dune
+++ b/XML/many_tests/dune
@@ -15,7 +15,17 @@
  (inline_tests))
 
 (cram
- (applies_to codegen codegen_llvm anf cc ll gc gc_llvm llvm_tweaks infer)
+ (applies_to
+  codegen
+  codegen_llvm
+  anf
+  cc
+  ll
+  gc
+  gc_llvm
+  llvm_tweaks
+  infer
+  unoptimized_codegen)
  (deps
   ../bin/XML.exe
   ../bin/XML_llvm.exe

--- a/XML/many_tests/optimization_diff.t
+++ b/XML/many_tests/optimization_diff.t
@@ -1,0 +1,3 @@
+the difference in lines:
+  $ echo $(($(wc -l < unoptimized_codegen.t) - $(wc -l < codegen.t)))
+  763

--- a/XML/many_tests/unit/anf.ml
+++ b/XML/many_tests/unit/anf.ml
@@ -79,7 +79,7 @@ let%expect_test "apply f x y" =
 
 let%expect_test "apply 1 + 2" =
   to_anf_prog {| 1 + 2 |};
-  [%expect{| 3;; |}]
+  [%expect{| let t_0 = (1 + 2) in t_0;; |}]
 
 
 let%expect_test "fun x -> x" =

--- a/XML/many_tests/unit/cc.ml
+++ b/XML/many_tests/unit/cc.ml
@@ -26,7 +26,7 @@ to_cc {|
 [%expect {|
   let fac = (fun n -> (let rec fack = (fun n k -> (if n <= 1
     then (k 1)
-    else (fack n - 1) (((fun k n m -> (k m * n)) k) n))) in (fack n) (fun x -> x)));; |}]
+    else ((fack n - 1) (((fun k n m -> (k m * n)) k) n)))) in ((fack n) (fun x -> x))));; |}]
 
 
 let%expect_test "LN_CC_1" =
@@ -68,9 +68,9 @@ to_cc {|
     greater_10
 |};
 [%expect {|
-  let f = (let ret1 = 1 in (let ret2 = 2 in (let greater_10 = ((fun ret1 ret2 x -> (if x > 10
+  let f = (let ret1 = 1 in (let ret2 = 2 in (let greater_10 = (((fun ret1 ret2 x -> (if x > 10
     then ret1
-    else ret2)) ret1) ret2 in (greater_10 ret1) ret2)));; |}]
+    else ret2)) ret1) ret2) in ((greater_10 ret1) ret2))));; |}]
 
 
 let%expect_test "tuple" =
@@ -81,7 +81,7 @@ to_cc {|
     to_tuple
 |};
 [%expect {|
-  let tuples = (let (a, b) = (10, 20) in (let to_tuple = ((fun a b x -> (x, a, b)) a) b in (to_tuple a) b));; |}]
+  let tuples = (let (a, b) = (10, 20) in (let to_tuple = (((fun a b x -> (x, a, b)) a) b) in ((to_tuple a) b)));; |}]
 
 
 let%expect_test "func" =
@@ -115,8 +115,8 @@ to_cc {|
     g
 |};
 [%expect{|
-  let f = (fun x -> (let y = 10 in (let g = ((fun x y z -> (match x with
+  let f = (fun x -> (let y = 10 in (let g = (((fun x y z -> (match x with
     | Some _ -> y
-    | _ -> z)) x) y in (g x) y)));; |}]
+    | _ -> z)) x) y) in ((g x) y))));; |}]
 
   

--- a/XML/many_tests/unit/codegen_llvm.ml
+++ b/XML/many_tests/unit/codegen_llvm.ml
@@ -49,7 +49,7 @@ let%expect_test "num" =
 
 let%expect_test "comp binop" =
   codegen_prog_str {| 1 + 2 |};
-  [%expect {|
+  [%expect{|
     ; ModuleID = 'main'
     source_filename = "main"
     target triple = "riscv64-unknown-linux-gnu"
@@ -76,7 +76,10 @@ let%expect_test "comp binop" =
 
     define i64 @main() {
     entry:
+      %t_0 = alloca i64, align 8
       call void @rt_init(i64 5120)
+      store i64 7, ptr %t_0, align 8
+      %t_01 = load i64, ptr %t_0, align 8
       call void @collect()
       ret i64 0
     } |}]

--- a/XML/many_tests/unit/ll.ml
+++ b/XML/many_tests/unit/ll.ml
@@ -166,8 +166,8 @@ to_ll {|
    (@) (fun x -> x) 5
 |};
 [%expect{|
-  let t_2 = t_2__ll$2 in let t_3 = (t_2 @ 5) in t_3;;
-  let (@__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = att__ll$1 t_2 5 in t_3;;
+  let att__ll$1 = fun f x -> let t_0 = f x in t_0;;
   let t_2__ll$2 = fun x -> x;; |}]
 
 
@@ -177,8 +177,8 @@ to_ll {|
    (fun x -> x) @ 5
 |};
 [%expect{|
-  let t_2 = t_2__ll$2 in let t_3 = (t_2 @ 5) in t_3;;
-  let (@__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = att__ll$1 t_2 5 in t_3;;
+  let att__ll$1 = fun f x -> let t_0 = f x in t_0;;
   let t_2__ll$2 = fun x -> x;; |}]
 
 
@@ -188,9 +188,9 @@ to_ll {|
    (@) (fun x -> x) 5;;
 |};
 [%expect{|
-  let (@) = fun f x -> let t_0 = f x in t_0;;
-  let t_2 = t_2__ll$1 in let t_3 = (t_2 @ 5) in t_3;;
-  let t_2__ll$1 = fun x -> x;; |}]
+  let att__ll$1 = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = att__ll$1 t_2 5 in t_3;;
+  let t_2__ll$2 = fun x -> x;; |}]
 
 
 
@@ -200,9 +200,9 @@ to_ll {|
    (fun x -> x) @ 5;;
 |};
 [%expect{|
-  let (@) = fun f x -> let t_0 = f x in t_0;;
-  let t_2 = t_2__ll$1 in let t_3 = (t_2 @ 5) in t_3;;
-  let t_2__ll$1 = fun x -> x;; |}]
+  let att__ll$1 = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = att__ll$1 t_2 5 in t_3;;
+  let t_2__ll$2 = fun x -> x;; |}]
 
 
 let%expect_test "override operator" =
@@ -211,8 +211,8 @@ to_ll {|
    (+) (fun x -> x) 5
 |};
 [%expect{|
-  let t_2 = t_2__ll$2 in let t_3 = (t_2 + 5) in t_3;;
-  let (+__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = pls__ll$1 t_2 5 in t_3;;
+  let pls__ll$1 = fun f x -> let t_0 = f x in t_0;;
   let t_2__ll$2 = fun x -> x;; |}]
 
 
@@ -223,6 +223,23 @@ to_ll {|
    (+) (fun x -> x) 5;;
 |};
 [%expect{|
-  let (+) = fun f x -> let t_0 = f x in t_0;;
-  let t_2 = t_2__ll$1 in let t_3 = (t_2 + 5) in t_3;;
-  let t_2__ll$1 = fun x -> x;; |}]
+  let pls__ll$1 = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$2 in let t_3 = pls__ll$1 t_2 5 in t_3;;
+  let t_2__ll$2 = fun x -> x;; |}]
+
+
+
+let%expect_test "override operator after using it" =
+to_ll {|
+  let g x y = x + y in
+  g 5 10;;
+
+  let (+) f x = f x;;
+   (+) (fun x -> x) 5;;
+|};
+[%expect{|
+  let t_2 = g__ll$1 5 in let t_3 = t_2 10 in t_3;;
+  let pls__ll$2 = fun f x -> let t_4 = f x in t_4;;
+  let t_6 = t_6__ll$3 in let t_7 = pls__ll$2 t_6 5 in t_7;;
+  let g__ll$1 = fun x y -> let t_0 = (x + y) in t_0;;
+  let t_6__ll$3 = fun x -> x;; |}]

--- a/XML/many_tests/unit/ll.ml
+++ b/XML/many_tests/unit/ll.ml
@@ -158,3 +158,71 @@ to_ll {|
                            in let t_2 = t_0[0]
                                 in let a = t_2
                                      in let t_1 = t_0[8] in let b = t_1 in a;; |}]
+
+
+let%expect_test "custom operator" =
+to_ll {|
+  let (@) f x = f x in
+   (@) (fun x -> x) 5
+|};
+[%expect{|
+  let t_2 = t_2__ll$2 in let t_3 = (t_2 @ 5) in t_3;;
+  let (@__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2__ll$2 = fun x -> x;; |}]
+
+
+let%expect_test "custom operator infix" =
+to_ll {|
+  let (@) f x = f x in
+   (fun x -> x) @ 5
+|};
+[%expect{|
+  let t_2 = t_2__ll$2 in let t_3 = (t_2 @ 5) in t_3;;
+  let (@__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2__ll$2 = fun x -> x;; |}]
+
+
+let%expect_test "custom operator 2" =
+to_ll {|
+  let (@) f x = f x;;
+   (@) (fun x -> x) 5;;
+|};
+[%expect{|
+  let (@) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$1 in let t_3 = (t_2 @ 5) in t_3;;
+  let t_2__ll$1 = fun x -> x;; |}]
+
+
+
+let%expect_test "custom operator 2 infix" =
+to_ll {|
+  let (@) f x = f x;;
+   (fun x -> x) @ 5;;
+|};
+[%expect{|
+  let (@) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$1 in let t_3 = (t_2 @ 5) in t_3;;
+  let t_2__ll$1 = fun x -> x;; |}]
+
+
+let%expect_test "override operator" =
+to_ll {|
+  let (+) f x = f x in
+   (+) (fun x -> x) 5
+|};
+[%expect{|
+  let t_2 = t_2__ll$2 in let t_3 = (t_2 + 5) in t_3;;
+  let (+__ll$1) = fun f x -> let t_0 = f x in t_0;;
+  let t_2__ll$2 = fun x -> x;; |}]
+
+
+
+let%expect_test "override operator 2" =
+to_ll {|
+  let (+) f x = f x;;
+   (+) (fun x -> x) 5;;
+|};
+[%expect{|
+  let (+) = fun f x -> let t_0 = f x in t_0;;
+  let t_2 = t_2__ll$1 in let t_3 = (t_2 + 5) in t_3;;
+  let t_2__ll$1 = fun x -> x;; |}]

--- a/XML/many_tests/unit/parser_infixop.ml
+++ b/XML/many_tests/unit/parser_infixop.ml
@@ -1,0 +1,196 @@
+(** Copyright 2026,  Mikhail Gavrilenko, Danila Rudnev-Stepanyan, Daniel Vlasenko *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Common.Parser
+open Common.Pprinter
+open Angstrom
+
+let (let*) = Angstrom.(let*)
+
+let parse_infix ?starts str =
+  match parse_string ~consume:All (pass_ws *> pinfix_op ?starts () <* pass_ws) str with
+  | Ok v -> Format.printf "%s\n" v
+  | Error e -> Format.printf "%s\n" e
+
+let parse str =
+  let prog = parse str in
+  match prog with
+  | Ok v ->  pprint_program Format.std_formatter v
+  | Error e -> Format.printf "%s\n" e
+
+
+(************************** Parse built in operators **************************)
+
+let%expect_test "parse op" =
+  parse_infix "*";
+  [%expect {| * |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "+";
+  [%expect {| + |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "-";
+  [%expect {| - |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "/";
+  [%expect {| / |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "&&";
+  [%expect {| && |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "||";
+  [%expect {| || |}]
+
+
+let%expect_test "parse op" =
+  parse_infix ">";
+  [%expect {| > |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "<";
+  [%expect {| < |}]
+
+
+let%expect_test "parse op" =
+  parse_infix "=";
+  [%expect {| = |}]
+
+
+let%expect_test "don't parse op with starts" =
+  parse_infix ~starts:"+" "*";
+  [%expect {| : string |}]
+
+
+(************************** Parse cursom operators **************************)
+
+
+let%expect_test "invalid custom op" =
+  parse_infix "!+";
+  [%expect {| : string |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix "+!";
+  [%expect {| +! |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix "**";
+  [%expect {| ** |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix "*!";
+  [%expect {| *! |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix "++";
+  [%expect {| ++ |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix "<*";
+  [%expect {| <* |}]
+
+
+let%expect_test "parse custom op" =
+  parse_infix ">>=";
+  [%expect {| >>= |}]
+
+
+let%expect_test "parse custom with starts" =
+  parse_infix ~starts:">" ">>=";
+  [%expect {| >>= |}]
+
+
+let%expect_test "parse custom with starts" =
+  parse_infix ~starts:">>" ">>=";
+  [%expect {| >>= |}]
+
+
+let%expect_test "parse custom with starts" =
+  parse_infix ~starts:"**" "***+";
+  [%expect {| ***+ |}]
+
+
+let%expect_test "don't parse custom with starts" =
+  parse_infix ~starts:"*" ">>=";
+  [%expect {| : string |}]
+
+
+let%expect_test "don't parse custom with starts" =
+  parse_infix ~starts:"**+" "***+";
+  [%expect {| : string |}]
+
+
+(************************** Parse custom operators as patterns **************************)
+
+let%expect_test "parse valid infix operator" =
+  parse {|
+    let (-!) x y = x - y;;
+  |};
+[%expect{| let (-!) = (fun x y -> x - y);; |}]
+
+
+let%expect_test "redefinition" =
+  parse {|
+    let (+) x y = x - y;;
+  |};
+[%expect{| let (+) = (fun x y -> x - y);; |}]
+
+
+let%expect_test "redefinition" =
+  parse {|
+    let (*) x y = x - y;;
+    let (*) x y = x + y;;
+  |};
+[%expect{|
+  let (*) = (fun x y -> x - y);;
+
+  let (*) = (fun x y -> x + y);; |}]
+
+
+let%expect_test "nested" =
+  parse {|
+    let (+) a b =
+      let (-) x y = x + y in
+      a - b
+  |};
+[%expect{| let (+) = (fun a b -> (let (-) = (fun x y -> x + y) in a - b));; |}]
+
+
+
+let%expect_test "invalid infix operator" =
+  parse {|
+    let (a+) x y = x + y;;
+  |};
+[%expect{| : end_of_input |}]
+
+
+let%expect_test "invalid infix operator" =
+  parse {|
+    let (~+) x = - x;;
+  |};
+[%expect{| : end_of_input |}]
+
+
+(************************** Parse custom operators as expressions **************************)
+
+let%expect_test "parse valid infix operator" =
+  parse {|
+    let f x y = x !+ y;;
+  |};
+[%expect{| : end_of_input |}]
+

--- a/XML/many_tests/unit/parser_infixop.ml
+++ b/XML/many_tests/unit/parser_infixop.ml
@@ -188,9 +188,104 @@ let%expect_test "invalid infix operator" =
 
 (************************** Parse custom operators as expressions **************************)
 
-let%expect_test "parse valid infix operator" =
+let%expect_test "parse infix operator in paren first" =
   parse {|
-    let f x y = x !+ y;;
+    let f x y = (**) x y;;
   |};
-[%expect{| : end_of_input |}]
+[%expect{| let f = (fun x y -> ((**) x) y);; |}]
 
+
+let%expect_test "parse infix operator in paren first" =
+  parse {|
+    let f x y = (>>=) x y;;
+  |};
+[%expect{| let f = (fun x y -> ((>>=) x) y);; |}]
+
+
+let%expect_test "parse infix operator in paren second (strange but ok)" =
+  parse {|
+    let f x y = x (>>=) y;;
+  |};
+[%expect{| let f = (fun x y -> (x >>=) y);; |}]
+
+
+
+let%expect_test "parse infix operator" =
+  parse {|
+    let f x y = x >>= y;;
+  |};
+[%expect{| let f = (fun x y -> x >>= y);; |}]
+
+
+let%expect_test "parse infix operator in paren third (strange but ok)" =
+  parse {|
+    let f x y = x y (>>=);;
+  |};
+[%expect{| let f = (fun x y -> (x y) >>=);; |}]
+
+
+(************************** Chain **************************)
+
+let%expect_test "chain **" =
+  parse {|
+    let f x y = x ** y ** z;;
+  |};
+[%expect{| let f = (fun x y -> x ** y ** z);; |}]
+
+
+let%expect_test "chain ** //" =
+  parse {|
+    let f x y = x ** y // z;;
+  |};
+[%expect{| let f = (fun x y -> x ** y // z);; |}]
+
+
+let%expect_test "chain ** ++" =
+  parse {|
+    let f x y = x ** y ++ z;;
+  |};
+[%expect{| let f = (fun x y -> x ** y ++ z);; |}]
+
+
+
+let%expect_test "chain ++ **" =
+  parse {|
+    let f x y = x ++ y ** z;;
+  |};
+[%expect{| let f = (fun x y -> x ++ y ** z);; |}]
+
+
+let%expect_test "chain ++ ** paren" =
+  parse {|
+    let f x y = x ++ (y ** z);;
+  |};
+[%expect{| let f = (fun x y -> x ++ y ** z);; |}]
+
+
+let%expect_test "chain ++ ** paren 2" =
+  parse {|
+    let f x y = (x ++ y) ** z;;
+  |};
+[%expect{| let f = (fun x y -> (x ++ y) ** z);; |}]
+
+
+
+let%expect_test "chain different *" =
+  parse {|
+    let f x y = x * (y *! z *+++ d);;
+  |};
+[%expect{| let f = (fun x y -> x * (y *! z *+++ d));; |}]
+
+
+let%expect_test "chain many" =
+  parse {|
+    let f x y = x * y ++ z *** d +++ c ++ y;;
+  |};
+[%expect{| let f = (fun x y -> x * y ++ z *** d +++ c ++ y);; |}]
+
+
+let%expect_test "chain many with parentheses" =
+  parse {|
+    let f x y = x * ((y ++ z) *** d +++ c) ++ y;;
+  |};
+[%expect{| let f = (fun x y -> x * ((y ++ z) *** d +++ c) ++ y);; |}]

--- a/XML/many_tests/unit/parser_infixop.ml
+++ b/XML/many_tests/unit/parser_infixop.ml
@@ -192,21 +192,21 @@ let%expect_test "parse infix operator in paren first" =
   parse {|
     let f x y = (**) x y;;
   |};
-[%expect{| let f = (fun x y -> ((**) x) y);; |}]
+[%expect{| let f = (fun x y -> x ** y);; |}]
 
 
 let%expect_test "parse infix operator in paren first" =
   parse {|
     let f x y = (>>=) x y;;
   |};
-[%expect{| let f = (fun x y -> ((>>=) x) y);; |}]
+[%expect{| let f = (fun x y -> x >>= y);; |}]
 
 
 let%expect_test "parse infix operator in paren second (strange but ok)" =
   parse {|
     let f x y = x (>>=) y;;
   |};
-[%expect{| let f = (fun x y -> (x >>=) y);; |}]
+[%expect{| let f = (fun x y -> ((x >>=) y));; |}]
 
 
 let%expect_test "parse infix operator" =
@@ -220,7 +220,7 @@ let%expect_test "parse infix operator in paren third (strange but ok)" =
   parse {|
     let f x y = x y (>>=);;
   |};
-[%expect{| let f = (fun x y -> (x y) >>=);; |}]
+[%expect{| let f = (fun x y -> ((x y) >>=));; |}]
 
 
 let%expect_test "now try function" =
@@ -229,7 +229,7 @@ let%expect_test "now try function" =
     (@) (fun x -> x) 5;;
   |};
 [%expect{|
-  let (@) = (fun f x -> (f x)) in ((@) (fun x -> x)) 5 ;; |}]
+  let (@) = (fun f x -> (f x)) in (fun x -> x @ 5) ;; |}]
 
 
 let%expect_test "now try function infix" =

--- a/XML/many_tests/unit/parser_infixop.ml
+++ b/XML/many_tests/unit/parser_infixop.ml
@@ -209,7 +209,6 @@ let%expect_test "parse infix operator in paren second (strange but ok)" =
 [%expect{| let f = (fun x y -> (x >>=) y);; |}]
 
 
-
 let%expect_test "parse infix operator" =
   parse {|
     let f x y = x >>= y;;
@@ -222,6 +221,26 @@ let%expect_test "parse infix operator in paren third (strange but ok)" =
     let f x y = x y (>>=);;
   |};
 [%expect{| let f = (fun x y -> (x y) >>=);; |}]
+
+
+let%expect_test "now try function" =
+  parse {|
+    let (@) f x = f x in
+    (@) (fun x -> x) 5;;
+  |};
+[%expect{|
+  let (@) = (fun f x -> (f x)) in ((@) (fun x -> x)) 5 ;; |}]
+
+
+let%expect_test "now try function infix" =
+  parse {|
+    let (@) f x = f x in
+    (fun x -> x) @ 5;;
+  |};
+[%expect{|
+  let (@) = (fun f x -> (f x)) in (fun x -> x @ 5) ;; |}]
+
+
 
 
 (************************** Chain **************************)

--- a/XML/many_tests/unit/parser_infixop.mli
+++ b/XML/many_tests/unit/parser_infixop.mli
@@ -1,0 +1,3 @@
+(** Copyright 2026,  Mikhail Gavrilenko, Danila Rudnev-Stepanyan, Daniel Vlasenko *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)

--- a/XML/many_tests/unoptimized_codegen.t
+++ b/XML/many_tests/unoptimized_codegen.t
@@ -1,0 +1,2490 @@
+this is a copy of codegen.t, but with peephole optimizations turned off
+
+  $ dune exec ./../bin/XML.exe -- -o factorial.s -no-opt-peep <<EOF
+  > let rec fac n = if n = 0 then 1 else n * fac (n - 1)
+  > 
+  > let main = print_int (fac 4)
+
+  $ cat factorial.s
+  .section .text
+  .global main
+  .type main, @function
+  fac:
+    addi sp, sp, -88
+    sd ra, 80(sp)
+    sd s0, 72(sp)
+    addi s0, sp, 72
+    mv t0, a0
+    li t1, 1
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    li t0, 3
+    j endif_1
+  else_0:
+    mv t0, a0
+    li t1, 3
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call fac
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    mv t0, a0
+    ld t1, -24(s0)
+    srai t2, t0, 1
+    srai t3, t1, 1
+    mul t0, t2, t3
+    add t0, t0, t0
+    addi t0, t0, 1
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+  endif_1:
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    li a0, 5120
+    call rt_init
+    li t0, 9
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call fac
+    mv t0, a0
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  $ riscv64-linux-gnu-as -march=rv64gc factorial.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  24
+
+====================== Fibonacci ======================
+  $ dune exec -- ../bin/XML.exe -o fibonacci.s -no-opt-peep <<EOF
+  > let rec fib n = if n <= 1 then n else fib (n - 1) + fib (n - 2)
+  > 
+  > let main = print_int (fib 6)
+
+  $ cat fibonacci.s
+  .section .text
+  .global main
+  .type main, @function
+  fib:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    li t1, 3
+    slt t2, t1, t0
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    mv t0, a0
+    j endif_1
+  else_0:
+    mv t0, a0
+    li t1, 3
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call fib
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    mv t0, a0
+    li t1, 5
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld t0, -32(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call fib
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld t0, -24(s0)
+    ld t1, -40(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+  endif_1:
+    sd t0, -56(s0)
+    ld a0, -56(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    li a0, 5120
+    call rt_init
+    li t0, 13
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call fib
+    mv t0, a0
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  $ riscv64-linux-gnu-as -march=rv64gc fibonacci.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  8
+
+====================== Ififif ======================
+  $ dune exec -- ../bin/XML.exe -o ififif.s -no-opt-peep <<EOF
+  > let large x = if 0<>x then print_int 0 else print_int 1
+  > let main =
+  >   let x = if (if (if 0 = 1
+  >                   then 0 = 1 else (let t42 = print_int 42 in 1 = 1))
+  >               then 0 else 1) = 1
+  >           then 0 else 1 in
+  >   large x
+
+  $ cat ififif.s
+  .section .text
+  .global main
+  .type main, @function
+  large:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    li t0, 1
+    mv t1, a0
+    xor t2, t0, t1
+    snez t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    li t0, 1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    j endif_1
+  else_0:
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    li t0, 3
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+  endif_1:
+    sd t0, -24(s0)
+    ld a0, -24(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -112
+    sd ra, 104(sp)
+    sd s0, 96(sp)
+    addi s0, sp, 96
+    li a0, 5120
+    call rt_init
+    li t0, 1
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_2
+    li t0, 1
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    j endif_3
+  else_2:
+    li t0, 85
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    li t0, 3
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+  endif_3:
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    beq t0, zero, else_4
+    li t0, 1
+    j endif_5
+  else_4:
+    li t0, 3
+  endif_5:
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -56(s0)
+    ld t0, -56(s0)
+    beq t0, zero, else_6
+    li t0, 1
+    j endif_7
+  else_6:
+    li t0, 3
+  endif_7:
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    ld t0, -72(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call large
+    mv t0, a0
+    sd t0, -80(s0)
+    ld a0, -80(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc ififif.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  42
+  0
+
+
+====================== Simple Closure ======================
+  $ dune exec -- ../bin/XML.exe -o closure.s -no-opt-peep <<EOF
+  > let simplesum x y = x + y
+  > let partialapp_sum = simplesum 5
+  > let main = print_int (partialapp_sum 5)
+  $ cat closure.s
+  .section .text
+  .global main
+  .type main, @function
+  simplesum:
+    addi sp, sp, -64
+    sd ra, 56(sp)
+    sd s0, 48(sp)
+    addi s0, sp, 48
+    mv t0, a0
+    mv t1, a1
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -8(s0)
+    ld a0, -8(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  partialapp_sum:
+    addi sp, sp, -64
+    sd ra, 56(sp)
+    sd s0, 48(sp)
+    addi s0, sp, 48
+    addi sp, sp, -8
+    li t1, 11
+    sd t1, 0(sp)
+    la a0, simplesum
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld a0, -8(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    li a0, 5120
+    call rt_init
+    call partialapp_sum
+    mv t0, a0
+    li t1, 11
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc closure.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  10
+
+
+
+====================== CPS Factorial ======================
+  $ dune exec -- ../bin/XML.exe -fromfile manytests/typed/010faccps_ll.ml -o 010faccps_ll.s -no-opt-peep
+
+  $ cat 010faccps_ll.s
+  .section .text
+  .global main
+  .type main, @function
+  id:
+    addi sp, sp, -56
+    sd ra, 48(sp)
+    sd s0, 40(sp)
+    addi s0, sp, 40
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  fresh_1:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    mv t0, a2
+    mv t1, a0
+    srai t2, t0, 1
+    srai t3, t1, 1
+    mul t0, t2, t3
+    add t0, t0, t0
+    addi t0, t0, 1
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    mv t0, a1
+    ld t1, -8(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  fac_cps:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    mv t0, a1
+    li t1, 3
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    j endif_1
+  else_0:
+    mv t0, a0
+    li t1, 3
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    ld t1, -16(s0)
+    sd t1, 0(sp)
+    la a0, fac_cps
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    mv t1, a0
+    sd t1, 0(sp)
+    la a0, fresh_1
+    li a1, 3
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -32(s0)
+    mv t1, a1
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -24(s0)
+    ld t1, -40(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+  endif_1:
+    sd t0, -56(s0)
+    ld a0, -56(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -80
+    sd ra, 72(sp)
+    sd s0, 64(sp)
+    addi s0, sp, 64
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    li t1, 9
+    sd t1, 0(sp)
+    la a0, fac_cps
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    la a0, id
+    li a1, 1
+    call alloc_closure
+    mv t1, a0
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -24(s0)
+    li a0, 1
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  $ riscv64-linux-gnu-as -march=rv64gc 010faccps_ll.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  24
+  [1]
+
+====================== CPS Fibbo ======================
+  $ dune exec -- ../bin/XML.exe -fromfile manytests/typed/010fibcps_ll.ml -o 010fibcps_ll.s -no-opt-peep
+
+  $ cat 010fibcps_ll.s
+  .section .text
+  .global main
+  .type main, @function
+  id:
+    addi sp, sp, -56
+    sd ra, 48(sp)
+    sd s0, 40(sp)
+    addi s0, sp, 40
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  fresh_2:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    mv t0, a0
+    mv t1, a2
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    mv t0, a1
+    ld t1, -8(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  fresh_1:
+    addi sp, sp, -96
+    sd ra, 88(sp)
+    sd s0, 80(sp)
+    addi s0, sp, 80
+    mv t0, a0
+    li t1, 5
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a3, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    mv t0, a2
+    ld t1, -8(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a3, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a3, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    mv t1, a3
+    sd t1, 0(sp)
+    la a0, fresh_2
+    li a1, 3
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a3, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a3, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    ld t0, -24(s0)
+    mv t1, a1
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a3, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a3, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    ld t0, -16(s0)
+    ld t1, -32(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a3, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  fib:
+    addi sp, sp, -112
+    sd ra, 104(sp)
+    sd s0, 96(sp)
+    addi s0, sp, 96
+    mv t0, a0
+    li t1, 5
+    slt t0, t0, t1
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    mv t0, a1
+    mv t1, a0
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    j endif_1
+  else_0:
+    mv t0, a0
+    li t1, 3
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    ld t1, -16(s0)
+    sd t1, 0(sp)
+    la a0, fib
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    mv t1, a0
+    sd t1, 0(sp)
+    la a0, fresh_1
+    li a1, 4
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -32(s0)
+    mv t1, a1
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -40(s0)
+    la a0, fib
+    li a1, 2
+    call alloc_closure
+    mv t1, a0
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -48(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -24(s0)
+    ld t1, -48(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -56(s0)
+    ld t0, -56(s0)
+  endif_1:
+    sd t0, -64(s0)
+    ld a0, -64(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -88
+    sd ra, 80(sp)
+    sd s0, 72(sp)
+    addi s0, sp, 72
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    li t1, 13
+    sd t1, 0(sp)
+    la a0, fib
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    la a0, id
+    li a1, 1
+    call alloc_closure
+    mv t1, a0
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    li a0, 1
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  $ riscv64-linux-gnu-as -march=rv64gc 010fibcps_ll.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  8
+  [1]
+
+  $ dune exec -- ../bin/XML.exe -fromfile manytests/typed/004manyargs.ml -o 004manyargs.s -no-opt-peep
+
+  $ cat 004manyargs.s
+  .section .text
+  .global main
+  .type main, @function
+  wrap:
+    addi sp, sp, -72
+    sd ra, 64(sp)
+    sd s0, 56(sp)
+    addi s0, sp, 56
+    li t0, 3
+    li t1, 3
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    mv t0, a0
+    j endif_1
+  else_0:
+    mv t0, a0
+  endif_1:
+    sd t0, -16(s0)
+    ld a0, -16(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  test3:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    mv t0, a1
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a2, 0(sp)
+    addi sp, sp, -8
+    mv t0, a2
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    addi sp, sp, 8
+    ld a2, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    sd t0, -48(s0)
+    li a0, 1
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  test10:
+    addi sp, sp, -128
+    sd ra, 120(sp)
+    sd s0, 112(sp)
+    addi s0, sp, 112
+    mv t0, a0
+    mv t1, a1
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    mv t1, a2
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    mv t1, a3
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    mv t1, a4
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    mv t1, a5
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    mv t1, a6
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    mv t1, a7
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -56(s0)
+    ld t0, -56(s0)
+    ld t1, 16(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    ld t1, 24(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -72(s0)
+    ld a0, -72(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -200
+    sd ra, 192(sp)
+    sd s0, 184(sp)
+    addi s0, sp, 184
+    li a0, 5120
+    call rt_init
+    la a0, test10
+    li a1, 10
+    call alloc_closure
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call wrap
+    mv t0, a0
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    li t1, 3
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    li t1, 21
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    li t1, 201
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    li t1, 2001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    li t1, 20001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    li t1, 200001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -56(s0)
+    ld t0, -56(s0)
+    li t1, 2000001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    li t1, 20000001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -72(s0)
+    ld t0, -72(s0)
+    li t1, 200000001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -80(s0)
+    ld t0, -80(s0)
+    li t1, 2000000001
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -88(s0)
+    ld t0, -88(s0)
+    sd t0, -96(s0)
+    ld t0, -96(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -104(s0)
+    la a0, test3
+    li a1, 3
+    call alloc_closure
+    mv t0, a0
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call wrap
+    mv t0, a0
+    sd t0, -112(s0)
+    ld t0, -112(s0)
+    li t1, 3
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -120(s0)
+    ld t0, -120(s0)
+    li t1, 21
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -128(s0)
+    ld t0, -128(s0)
+    li t1, 201
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -136(s0)
+    ld t0, -136(s0)
+    sd t0, -144(s0)
+    li a0, 1
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc 004manyargs.s -o temp.o
+  $ riscv64-linux-gnu-gcc -c ../bin/runtime.c -o runtime.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  1111111111
+  1
+  10
+  100
+  [1]
+
+  $ dune exec -- ../bin/XML.exe -o tuple_return.s -no-opt-peep <<EOF
+  > let make_pair x y = (x, y)
+  > 
+  > let main =
+  >   let p = make_pair 10 20 in
+  >   let (a, b) = p in
+  >   print_int (a + b)
+  $ cat tuple_return.s
+  .section .text
+  .global main
+  .type main, @function
+  make_pair:
+    addi sp, sp, -64
+    sd ra, 56(sp)
+    sd s0, 48(sp)
+    addi s0, sp, 48
+    addi sp, sp, -8
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 16(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    mv t1, a0
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    mv t1, a1
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld a0, -8(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -136
+    sd ra, 128(sp)
+    sd s0, 120(sp)
+    addi s0, sp, 120
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    li t1, 21
+    sd t1, 0(sp)
+    la a0, make_pair
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    li t1, 41
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    sd t0, -48(s0)
+    ld a0, -32(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld t0, -56(s0)
+    sd t0, -64(s0)
+    ld t0, -48(s0)
+    ld t1, -64(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -72(s0)
+    ld t0, -72(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -80(s0)
+    ld a0, -80(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_return.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  30
+
+  $ dune exec -- ../bin/XML.exe -o tuple_swap.s -no-opt-peep <<EOF
+  > let swap p =
+  >   let (a, b) = p in
+  >   (b, a)
+  > 
+  > let main =
+  >   let p1 = (1, 2) in
+  >   let p2 = swap p1 in
+  >   let (x, y) = p2 in
+  >   print_int x
+  $ cat tuple_swap.s
+  .section .text
+  .global main
+  .type main, @function
+  swap:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    li a0, 2
+    call create_tuple
+    sd a0, 8(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    ld t1, -40(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -24(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -136
+    sd ra, 128(sp)
+    sd s0, 120(sp)
+    addi s0, sp, 120
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 3
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call swap
+    mv t0, a0
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    sd t0, -56(s0)
+    ld a0, -40(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    ld t0, -56(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -80(s0)
+    ld a0, -80(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_swap.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  2
+
+  $ dune exec -- ../bin/XML.exe -o tuple_order.s -no-opt-peep <<EOF
+  > let f n =
+  >   n
+  > 
+  > let main =
+  >   let t = (f 10, f 20) in
+  >   let (a, b) = t in
+  >   print_int (a + b)
+  $ cat tuple_order.s
+  .section .text
+  .global main
+  .type main, @function
+  f:
+    addi sp, sp, -56
+    sd ra, 48(sp)
+    sd s0, 40(sp)
+    addi s0, sp, 40
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -144
+    sd ra, 136(sp)
+    sd s0, 128(sp)
+    addi s0, sp, 128
+    li a0, 5120
+    call rt_init
+    li t0, 21
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call f
+    mv t0, a0
+    sd t0, -8(s0)
+    li t0, 41
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call f
+    mv t0, a0
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -16(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    sd t0, -56(s0)
+    ld a0, -40(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    ld t0, -56(s0)
+    ld t1, -72(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -80(s0)
+    ld t0, -80(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -88(s0)
+    ld a0, -88(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_order.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  30
+
+  $ dune exec -- ../bin/XML.exe -o tuple_linked_list.s -notypes -no-opt-peep <<EOF
+  > let rec sum_list lst =
+  >   if lst = 0 then 0 else
+  >   let (head, tail) = lst in
+  >   head + sum_list tail
+  > 
+  > let main =
+  >   let lst = (10, (20, (30, 0))) in
+  >   print_int (sum_list lst)
+  $ cat tuple_linked_list.s
+  .section .text
+  .global main
+  .type main, @function
+  sum_list:
+    addi sp, sp, -120
+    sd ra, 112(sp)
+    sd s0, 104(sp)
+    addi s0, sp, 104
+    mv t0, a0
+    li t1, 1
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    li t0, 1
+    j endif_1
+  else_0:
+    mv t0, a0
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -16(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -16(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    sd t0, -48(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld t0, -48(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_list
+    mv t0, a0
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -56(s0)
+    ld t0, -32(s0)
+    ld t1, -56(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+  endif_1:
+    sd t0, -72(s0)
+    ld a0, -72(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 61
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 1
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -16(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_list
+    mv t0, a0
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_linked_list.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  60
+
+  $ dune exec -- ../bin/XML.exe -o tuple_large.s -no-opt-peep <<EOF
+  > let main =
+  >   let t = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) in
+  >   let (a, b, c, d, e, f, g, h, i, j) = t in
+  >   print_int j
+  $ cat tuple_large.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -248
+    sd ra, 240(sp)
+    sd s0, 232(sp)
+    addi s0, sp, 232
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 10
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 3
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    li t1, 7
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 16(t2)
+    li t1, 9
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 24(t2)
+    li t1, 11
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 32(t2)
+    li t1, 13
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 40(t2)
+    li t1, 15
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 48(t2)
+    li t1, 17
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 56(t2)
+    li t1, 19
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 64(t2)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 72(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    ld a0, -24(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld a0, -24(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    sd t0, -56(s0)
+    ld a0, -24(s0)
+    li a1, 2
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    ld a0, -24(s0)
+    li a1, 3
+    call field
+    mv t0, a0
+    sd t0, -80(s0)
+    ld t0, -80(s0)
+    sd t0, -88(s0)
+    ld a0, -24(s0)
+    li a1, 4
+    call field
+    mv t0, a0
+    sd t0, -96(s0)
+    ld t0, -96(s0)
+    sd t0, -104(s0)
+    ld a0, -24(s0)
+    li a1, 5
+    call field
+    mv t0, a0
+    sd t0, -112(s0)
+    ld t0, -112(s0)
+    sd t0, -120(s0)
+    ld a0, -24(s0)
+    li a1, 6
+    call field
+    mv t0, a0
+    sd t0, -128(s0)
+    ld t0, -128(s0)
+    sd t0, -136(s0)
+    ld a0, -24(s0)
+    li a1, 7
+    call field
+    mv t0, a0
+    sd t0, -144(s0)
+    ld t0, -144(s0)
+    sd t0, -152(s0)
+    ld a0, -24(s0)
+    li a1, 8
+    call field
+    mv t0, a0
+    sd t0, -160(s0)
+    ld t0, -160(s0)
+    sd t0, -168(s0)
+    ld a0, -24(s0)
+    li a1, 9
+    call field
+    mv t0, a0
+    sd t0, -176(s0)
+    ld t0, -176(s0)
+    sd t0, -184(s0)
+    ld t0, -184(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -192(s0)
+    ld a0, -192(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_large.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  10
+
+  $ dune exec -- ../bin/XML.exe -o tuple_basic.s -no-opt-peep <<EOF
+  > let main =
+  >   let t = (10, 20) in
+  >   let (a, b) = t in
+  >   print_int (a + b)
+  $ cat tuple_basic.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -128
+    sd ra, 120(sp)
+    sd s0, 112(sp)
+    addi s0, sp, 112
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 21
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    ld a0, -24(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld a0, -24(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    sd t0, -56(s0)
+    ld t0, -40(s0)
+    ld t1, -56(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -72(s0)
+    ld a0, -72(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_basic.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  30
+
+  $ dune exec -- ../bin/XML.exe -o tuple_nested.s -no-opt-peep <<EOF
+  > let main =
+  >   let complex = (100, (20, 3)) in
+  >   let (a, (b, c)) = complex in
+  >   print_int (a + b + c)
+  $ cat tuple_nested.s
+  .section .text
+  .global main
+  .type main, @function
+  main:
+    addi sp, sp, -168
+    sd ra, 160(sp)
+    sd s0, 152(sp)
+    addi s0, sp, 152
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 41
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 7
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 201
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    ld t1, -8(s0)
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+    sd t0, -48(s0)
+    ld a0, -32(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -56(s0)
+    ld a0, -56(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    ld a0, -56(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -80(s0)
+    ld t0, -80(s0)
+    sd t0, -88(s0)
+    ld t0, -48(s0)
+    ld t1, -72(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -96(s0)
+    ld t0, -96(s0)
+    ld t1, -88(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -104(s0)
+    ld t0, -104(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -112(s0)
+    ld a0, -112(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_nested.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  123
+
+  $ dune exec -- ../bin/XML.exe -o tuple_arg.s -no-opt-peep <<EOF
+  > let sum_pair p =
+  >   let (x, y) = p in
+  >   x + y
+  > 
+  > let main =
+  >   let p = (40, 2) in
+  >   print_int (sum_pair p)
+  $ cat tuple_arg.s
+  .section .text
+  .global main
+  .type main, @function
+  sum_pair:
+    addi sp, sp, -104
+    sd ra, 96(sp)
+    sd s0, 88(sp)
+    addi s0, sp, 88
+    mv t0, a0
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 0
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    ld a0, -8(s0)
+    li a1, 1
+    call field
+    addi sp, sp, 8
+    mv t0, a0
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld t0, -24(s0)
+    ld t1, -40(s0)
+    add t0, t0, t1
+    addi t0, t0, -1
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -88
+    sd ra, 80(sp)
+    sd s0, 72(sp)
+    addi s0, sp, 72
+    li a0, 5120
+    call rt_init
+    addi sp, sp, -8
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 0(sp)
+    li t1, 81
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    li t1, 5
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call sum_pair
+    mv t0, a0
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -32(s0)
+    ld a0, -32(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_arg.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  42
+
+  $ dune exec -- ../bin/XML.exe -o tuple_gc_stress.s -notypes -no-opt-peep <<EOF
+  > let rec make_list n acc =
+  >   if n = 0 then acc else
+  >   make_list (n - 1) (n, acc)
+  > 
+  > let main =
+  >   let _ = print_gc_status in
+  >   let result = make_list 10000 0 in
+  >   let (head, tail) = result in
+  >   let _ = print_gc_status in
+  >   print_int head
+  $ cat tuple_gc_stress.s
+  .section .text
+  .global main
+  .type main, @function
+  make_list:
+    addi sp, sp, -96
+    sd ra, 88(sp)
+    sd s0, 80(sp)
+    addi s0, sp, 80
+    mv t0, a0
+    li t1, 1
+    xor t2, t0, t1
+    seqz t0, t2
+    sd t0, -8(s0)
+    ld t0, -8(s0)
+    beq t0, zero, else_0
+    mv t0, a1
+    j endif_1
+  else_0:
+    mv t0, a0
+    li t1, 3
+    sub t0, t0, t1
+    addi t0, t0, 1
+    sd t0, -16(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    ld t1, -16(s0)
+    sd t1, 0(sp)
+    la a0, make_list
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -24(s0)
+    addi sp, sp, -8
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    addi sp, sp, -8
+    li a0, 2
+    call create_tuple
+    addi sp, sp, 8
+    sd a0, 16(sp)
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    mv t1, a0
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 0(t2)
+    mv t1, a1
+    ld t2, 0(sp)
+    addi t2, t2, 16
+    sd t1, 8(t2)
+    ld t0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -32(s0)
+    addi sp, sp, -8
+    sd a0, 0(sp)
+    addi sp, sp, -8
+    sd a1, 0(sp)
+    ld t0, -24(s0)
+    ld t1, -32(s0)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    ld a1, 0(sp)
+    addi sp, sp, 8
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    sd t0, -40(s0)
+    ld t0, -40(s0)
+  endif_1:
+    sd t0, -48(s0)
+    ld a0, -48(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  main:
+    addi sp, sp, -144
+    sd ra, 136(sp)
+    sd s0, 128(sp)
+    addi s0, sp, 128
+    li a0, 5120
+    call rt_init
+    call print_gc_status
+    mv t0, a0
+    sd t0, -8(s0)
+    addi sp, sp, -8
+    li t1, 20001
+    sd t1, 0(sp)
+    la a0, make_list
+    li a1, 2
+    call alloc_closure
+    mv t0, a0
+    ld t1, 0(sp)
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    addi sp, sp, 8
+    sd t0, -16(s0)
+    ld t0, -16(s0)
+    li t1, 1
+    mv a0, t0
+    mv a1, t1
+    call apply1
+    mv t0, a0
+    sd t0, -24(s0)
+    ld t0, -24(s0)
+    sd t0, -32(s0)
+    ld t0, -32(s0)
+    sd t0, -40(s0)
+    ld a0, -40(s0)
+    li a1, 0
+    call field
+    mv t0, a0
+    sd t0, -48(s0)
+    ld t0, -48(s0)
+    sd t0, -56(s0)
+    ld a0, -40(s0)
+    li a1, 1
+    call field
+    mv t0, a0
+    sd t0, -64(s0)
+    ld t0, -64(s0)
+    sd t0, -72(s0)
+    call print_gc_status
+    mv t0, a0
+    sd t0, -80(s0)
+    ld t0, -56(s0)
+    addi sp, sp, -8
+    sd t0, 0(sp)
+    ld a0, 0(sp)
+    addi sp, sp, 8
+    call print_int
+    mv t0, a0
+    sd t0, -88(s0)
+    ld a0, -88(s0)
+    addi sp, s0, 16
+    ld ra, 8(s0)
+    ld s0, 0(s0)
+    ret
+  $ riscv64-linux-gnu-as -march=rv64gc tuple_gc_stress.s -o temp.o
+  $ riscv64-linux-gnu-gcc temp.o runtime.o -o prog.exe
+  $ qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64 ./prog.exe
+  === GC Status ===
+  Current allocated: 0
+  Free        space: 524288
+  Heap         size: 524288
+  Current      bank: 0
+  Total   allocated: 0
+  GC    collections: 0
+  GC    allocations: 0
+  =================
+  === GC Status ===
+  Current allocated: 231552
+  Free        space: 292736
+  Heap         size: 524288
+  Current      bank: 0
+  Total   allocated: 1280096
+  GC    collections: 2
+  GC    allocations: 30002
+  =================
+  1
+


### PR DESCRIPTION
Добавил:
- Возможность создавать и переопределять инфиксные операторы с приоритетами как в OCaml. Тесты в `many_tests/codegen_operators.t`
- Peephole оптимизатор. Чтобы сравнить до/после, добавил все тесты кодгена с и без оптимизатора. Diff можно посмотреть в `many_tests/optimization_diff.t`


Пример оптимизации
до:
```
    sd t0, -8(s0)
    ld t0, -8(s0)
    sd t0, -16(s0)
    ld t0, -16(s0)
    addi sp, sp, -8
    sd t0, 0(sp)
    ld a0, 0(sp)
    addi sp, sp, 8
```
после:
```
    mv a0, t0
```